### PR TITLE
css: Tweak page min-width size to 1100px

### DIFF
--- a/static/css/shijin4.css
+++ b/static/css/shijin4.css
@@ -29,7 +29,7 @@ a {
 }
 
 #page {
-	max-width: 965px;
+	max-width: 1100px;
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
* The minimum user screensize in 2014 was 1024x768 at
  3.7% of web broswsers (mobile + non).
* This change means the minimum "desktop" resolution to
  display our site is 1024x768
* The site already dynamically scales to a mobile view
  on smaller screens.
* This should give us more room for content making our
  site look less constricted and antiquated to most users.