### PR TITLE
Reset fundraising themometer for 2017

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
 			</div>
 		</div>
 		<div class="col-md-4" id="preface-last">
-			<h2 class="fundraising">Fundraising 2016</h2>
+			<h2 class="fundraising">Fundraising 2017</h2>
 			<div class="content">
 				<div style="margin-top: 30px;">
 					<div style="background-image:url(/files/images/piggy-bank.png);background-repeat:no-repeat; background-position: left; font-size: 0.9em; padding-bottom: 8px;">
@@ -60,9 +60,9 @@
 								<span style="top:-19px; position: relative; left:26px;
 											border-bottom: 1px solid #666;">Goal:&nbsp;$35,000</span>
 								<div style="position:absolute; margin:0px;
-											background: #3C3; bottom:0px; width: 20px; height: 32px;">
+											background: #3C3; bottom:0px; width: 20px; height: 0px;">
 									<span style="position: relative; left:22px; top: -18px;
-												border-bottom: 1px solid #666;">$8,724</span>
+												border-bottom: 1px solid #666;">$0</span>
 								</div>
 							</div>
 						</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,16 +60,16 @@
 								<span style="top:-19px; position: relative; left:26px;
 											border-bottom: 1px solid #666;">Goal:&nbsp;$35,000</span>
 								<div style="position:absolute; margin:0px;
-											background: #3C3; bottom:0px; width: 20px; height: 0px;">
+											background: #3C3; bottom:0px; width: 20px; height: 2.67px;">
 									<span style="position: relative; left:22px; top: -18px;
-												border-bottom: 1px solid #666;">$0</span>
+												border-bottom: 1px solid #666;">$730.63</span>
 								</div>
 							</div>
 						</div>
 					</div>
 					<ul>
-						<li>Updated: December 8th</li>
-						<li>€1 = $1.0762</li>
+						<li>Updated: February 9th</li>
+						<li>€1 = $1.0665</li>
 						<li><a href="http://www.haiku-inc.org/donations.html#online" target="_blank">Submit a Donation</a></li>
 						<li><a href="http://www.haiku-inc.org/donations-analysis.php" target="_blank">Donation Analysis</a></li>
 					</ul>


### PR DESCRIPTION
Addresses [my comment](https://dev.haiku-os.org/ticket/11154#comment:20) on bug [#11154](https://dev.haiku-os.org/ticket/11154):

> Can we get the Fundraising heading on the website home page updated and the the amount reset?
>
> "Fundraising 2016", is one of the most prominent headings above the fold when you land on the home page and the reference to 2016 makes it feel out of date.