### PR TITLE
Escape code that contains brackets

### DIFF
--- a/content/development/coding-guidelines.html
+++ b/content/development/coding-guidelines.html
@@ -474,11 +474,11 @@ bool doThings = value;
 
 <ul>
 <li>Use the built-in <code>false</code>/<code>true</code> instead of the <code>FALSE</code>/<code>TRUE</code> <code>#defines</code>.</li>
-<li>Alphabetize <code>#include</code> statements, group <code>"includes"</code> and <code><includes></code> separately.</li>
+<li>Alphabetize <code>#include</code> statements, group <code>"includes"</code> and <code>{{< html-escape >}}<includes>{{< /html-escape >}}</code> separately.</li>
 <li>While the header that belongs to a source file should be included first to ensure self containment, all other headers are specified from most general (POSIX) to most specific (local directory). In order to alphabetize them, please group them by API origin, like (but without the comments, of course):</li>
 </ul>
 
-<pre>
+<pre>{{< html-escape >}}
 #include "ThisClass.h"
 
 // POSIX API headers
@@ -492,10 +492,10 @@ bool doThings = value;
 #include <PrivateHeader.h>
 
 #include "OtherLocalHeaders.h"
-</pre>
+{{< /html-escape >}}</pre>
 
 <ul>
-<li>Don&#39;t use <code><pathname/include.h></code> if they aren't necessary; (like for <code><sys/stat.h></code>).</li>
+<li>Don&#39;t use <code>{{< html-escape >}}<pathname/include.h>{{< /html-escape >}}</code> if they aren't necessary; (like for <code>{{< html-escape >}}<sys/stat.h>{{< /html-escape >}}</code>).</li>
 <li>Use <code>NULL</code> instead of <code>0</code> for pointers.</li>
 <li>Avoid gotos.</li>
 <li>Don&#39;t use constructor call syntax for initializing pointers, etc. to <code>NULL</code> like this:</li>

--- a/layouts/shortcodes/html-escape.html
+++ b/layouts/shortcodes/html-escape.html
@@ -1,0 +1,1 @@
+{{ .Inner | htmlEscape | safeHTML }}


### PR DESCRIPTION
Fixes Trac [#13319](https://dev.haiku-os.org/ticket/13319)

How it currently looks:

![old](https://cloud.githubusercontent.com/assets/271035/23141453/c5d0652c-f76b-11e6-8327-dc31f7e95cf6.png)

How it'll look with this fix:

![new](https://cloud.githubusercontent.com/assets/271035/23141460/cae2624a-f76b-11e6-981f-18131b43f70b.png)