### PR TITLE
Update movies page

### DIFF
--- a/content/about/movies.html
+++ b/content/about/movies.html
@@ -14,16 +14,9 @@ tags = []
 <li><a href="http://haiku-files.org/files/media/HaikuRocks.mpg">Haiku-files.org</a> (MPEG, 54MB)</li>
 </ul>
 
-<h4>Introduction to Haiku - September 5, 2006 by Phil Greenway (Sikosis)</h4>
-<ul>
-<li><a href="http://haikupodcast.com/20060905/haiku-podcast-5-video/">Announcement with download links (below)</a></li>
-<li><a href="http://sikosis.com/haiku/Haiku05.m4v">Direct download</a> (low quality MP4, 15MB)</li>
-<li><a href="http://sikosis.com/haiku/Haiku05.divx">Direct download</a> (higher quality DivX, 56MB)</li>
-</ul>
-
 <h4>Haiku Tech Talk at Google - February 13, 2007 by Axel Dörfler, Bruno G. Albuquerque and Michael Phipps</h4>
 <ul>
-<li><a href="http://torrents.thepiratebay.org/4530702/Google_Tech_Talk_-_Haiku_The_Operating_System_2007-02-13.avi.4530702.TPB.torrent">BitTorrent</a> (DivX, 195MB)</li>
+<li><a href="https://www.youtube.com/watch?v=LxAQxGQB1A8">YouTube</a></li>
 <li><a href="http://haiku-files.org/files/media/Google%20Tech%20Talk%20-%20Haiku%20The%20Operating%20System%202007-02-13.avi">Haiku-files.org</a> (DivX, 195MB)</li>
 </ul>
 
@@ -35,23 +28,22 @@ tags = []
 <h4>FalterCon 2007 - Haiku at Picn*x - August 11, 2007 by Michael Summers and Urias McCullough, edited and produced by Phil Greenway</h4>
 <ul>
 <li><a href="http://www.youtube.com/watch?v=jG2Pp99qqeY">YouTube</a></li>
-<li><a href="http://torrents.thepiratebay.org/3780596/FalterCon_2007_-_Haiku_at_Picn_x.3780596.TPB.torrent">BitTorrent</a> (MP4, 141MB)</li>
 <li><a href="http://haiku-files.org/files/media/FalterCon2007.mp4">Haiku-files.org</a> (MP4, 141MB)</li>
 </ul>
 
 <h4>Code_Swarm for Haiku - July 21, 2008 by Fredrik Holmqvist</h4>
 <ul>
-<li><a href="http://vimeo.com/1393242">Vimeo</a> (requires Flash; MP4 download also available with login)</li>
+<li><a href="http://vimeo.com/1393242">Vimeo</a></li>
 </ul>
 
 <h4>Haiku Presentation - September 27, 2008 by Leszek Lesner</h4>
 <ul>
-<li><a href="http://blip.tv/file/1299707">BlipTV</a> (requires Flash; FLV or MP4 download also available)</li>
+<li><a href="https://www.youtube.com/watch?v=TqD4q_AeSsY">YouTube</a></li>
 </ul>
 
 <h4>Haiku at Linux Conference Australia 2011 (LCA2011) - January 28, 2011 by Phil Greenway</h4>
 <ul>
-<li><a href="http://linuxconfau.blip.tv/file/4728987/">BlipTV</a> (requires Flash; FLV, OGV or MP4 download also available)</li>
+<li><a href="https://www.youtube.com/watch?v=j4aE6pJzZzU">YouTube</a></li>
 </ul>
 
 <h4>Videos taken at the BeGeistert meetings</h4>
@@ -59,12 +51,12 @@ tags = []
 <li><a href="https://www.youtube.com/user/HumdingerB/playlists">Playlists at YouTube</a></li>
 </ul>
 
-<h3>Video Tutorials</h4>
-
-<h4>Creating Icons Using Icon-O-Matic &#151; Produced by LL electronics</h4>
+<h4>Haiku OS overview on Lunduke Hour podcast - Febrary 6, 2017</h4>
 <ul>
-<li><a href="http://blip.tv/file/1299791">BlipTV</a> (requires Flash; FLV or MP4 download also available)</li>
+<li><a href="https://www.youtube.com/watch?v=r4sTwDpHVDY">YouTube</a></li>
 </ul>
+
+<h3>Video Tutorials</h4>
 
 <h4>Videos done by students for Google Code-In</h4>
 <ul>

--- a/content/about/movies.html
+++ b/content/about/movies.html
@@ -51,7 +51,7 @@ tags = []
 <li><a href="https://www.youtube.com/user/HumdingerB/playlists">Playlists at YouTube</a></li>
 </ul>
 
-<h4>Haiku OS overview on Lunduke Hour podcast - Febrary 6, 2017</h4>
+<h4>Haiku overview on Lunduke Hour podcast - Febrary 6, 2017</h4>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=r4sTwDpHVDY">YouTube</a></li>
 </ul>

--- a/content/about/movies.html
+++ b/content/about/movies.html
@@ -51,7 +51,7 @@ tags = []
 <li><a href="https://www.youtube.com/user/HumdingerB/playlists">Playlists at YouTube</a></li>
 </ul>
 
-<h4>Haiku overview on Lunduke Hour podcast - Febrary 6, 2017</h4>
+<h4>Haiku overview on Lunduke Hour podcast - February 6, 2017</h4>
 <ul>
 <li><a href="https://www.youtube.com/watch?v=r4sTwDpHVDY">YouTube</a></li>
 </ul>


### PR DESCRIPTION
Fixes Trac #11305

- Remove dead links for sikosis.com - haikupodcast.com is dead, movie files are missing. I contacted author to see if they still have them.
- Remove dead torrent links (iffy to link there as those sites can be NSFW)
- Remove mention of Flash for YouTube as YT uses HTML5
- Removed Icon-O-Matic link. Link on author’s blog post goes to Google Video which no longer exists
- Added latest podcast video posted on Haiku blog