### PR TITLE
Fix conference list

### DIFF
--- a/themes/shijin4/layouts/taxonomy/conference.terms.html
+++ b/themes/shijin4/layouts/taxonomy/conference.terms.html
@@ -15,11 +15,11 @@
 				
 				<p>The table below shows upcoming Haiku-related events and conferences where Haiku is scheduled to have a presence, either in the form of a booth, a talk or both. For more information for any specific event, click on the corresponding link under the <strong>Name</strong> column.</p>
 				
-				{{ $now := dateFormat "2006-01-02" .Site.LastChange }}
+				{{ $now := .Site.LastChange.Unix }}
 
 				{{ $.Scratch.Add "haveCurrentEvents" 0 }}
-				{{ range (where .Site.Pages "Type" "conference") }}
-					{{ if ge .Params.event.end $now }}
+				{{ range where (where .Site.Pages "Type" "conference") ".Params.event" "!=" nil }}
+					{{ if ge (time .Params.event.end).Unix $now }}
 						{{ $.Scratch.Add "haveCurrentEvents" 1 }}
 					{{ end }}
 				{{ end }}
@@ -32,8 +32,8 @@
 						<th>Homepage</th>
 						<th>Country</th>
 					</tr>
-					{{ range (sort (where .Site.Pages "Type" "conference") "Date" "desc") }}
-						{{ if ge .Params.event.end $now }}
+					{{ range (sort (where (where .Site.Pages "Type" "conference") ".Params.event" "!=" nil) "Date" "desc") }}
+						{{ if ge (time .Params.event.end).Unix $now }}
 						<tr>
 							<td><a href="{{ .URL }}">{{ .Title }}</a></td>
 							<td style="white-space: nowrap;">{{ .Params.event.start }} - {{ .Params.event.end }}</td>
@@ -50,7 +50,6 @@
 				<div class="clearfix"></div>
 
 				<h3>Past Events</h3>
-
 				<table class="table table-condensed table-responsive">
 					<tr>
 						<th>Name</th>
@@ -58,8 +57,8 @@
 						<th>Homepage</th>
 						<th>Country</th>
 					</tr>
-					{{ range (sort (where .Site.Pages "Type" "conference") "Date" "desc") }}
-						{{ if lt .Params.event.start $now }}
+					{{ range (sort (where (where .Site.Pages "Type" "conference") ".Params.event" "!=" nil) "Date" "desc") }}
+						{{ if lt (time .Params.event.start).Unix $now }}
 						<tr>
 							<td><a href="{{ .URL }}">{{ .Title }}</a></td>
 							<td style="white-space: nowrap;">{{ .Params.event.start }} - {{ .Params.event.end }}</td>


### PR DESCRIPTION
Somehow Alchimie12 didn't get listed.

I believe ge only works on numbers...
converting all dates to Unix format seems to solve the issue.
We need to filter out pages without an event property though.