### PR TITLE
Spice up meta tags; add proper OpenGraph for website and article types

### DIFF
--- a/themes/shijin4/layouts/partials/meta.html
+++ b/themes/shijin4/layouts/partials/meta.html
@@ -3,5 +3,24 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	{{ if .Description }}<meta name="description" content="{{ .Description }}">{{ end }}
+	{{ if isset .Params "tags" }}<meta name="keywords" content="{{ delimit .Params.tags "," }}">{{ end }}
 	<meta name="copyright" content="2001-2017 Haiku Inc.">
-	<meta property="og:image" content="/images/haiku_600x315.png">
+	<meta property="og:site_name" content="{{ .Site.Title }}">
+	<meta property="og:title" content="{{ .Title }}">
+	<meta property="og:url" content="{{ .Permalink }}">
+	{{ if in (slice "news" "blog") .Type }}
+	<meta property="og:type" content="article">
+	<meta property="og:description" content="{{ plainify .Summary | truncate 250 }}">
+	<meta property="og:published_time" content="{{ .Date }}">
+	{{ if isset .Params "author" }}
+	<meta property="og:author" content="{{ .Params.author }}">
+	{{ end }}
+	{{ $baseurl := .Site.BaseURL }}
+	{{ range $i, $e := findRE "(?:<img[^>]*src=\")[^\"]*" .Content 4 }}
+	<meta property="og:image" content="{{ $e | replaceRE ".*\"" $baseurl }}">
+	{{ end }}
+	{{ else }}
+	<meta property="og:type" content="website">
+	<meta property="og:image" content="{{ .Site.BaseURL }}/images/haiku_600x315.png">
+	{{ end }}
+


### PR DESCRIPTION
Images must use canonical URLs.

For news and blog posts we use og:type = article.

For other pages we stick to og:type = website.