### PR TITLE
Add user guide styles to shijin4.css

### DIFF
--- a/themes/shijin4/static/css/shijin4.css
+++ b/themes/shijin4/static/css/shijin4.css
@@ -474,15 +474,51 @@ ul.pagination {
 	color: #666;
 }
 
-.button {
+.app {				/* GUI application name */
+	font-size: 1.0em;
+	font-family: serif;
+	font-style: italic;
+	color: #5e1c1c;
+}
+.button {			/* Button */
 	border: 1px solid #c7c7c7;
 	border-bottom: 1px solid #aaa;
 	border-right: 1px solid #aaa;
 	border-radius: 3px;
-	padding: 1px 5px 1px 5px;
+	padding: 1px 15px 1px 15px;
 	background-color: #e8e8e8;
 	font-size: 0.9em;
 	margin: 0 3px 0 3px;
+}
+.cli {				/* Shell command or file */
+	background-color: #e8e8e8;
+	font-size: 0.9em;
+	font-family: monospace;
+}
+.key {				/* Shortcut (separate with &nbsp; */
+	-webkit-border-radius: 3px;
+	-khtml-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+	border-color: #c7c7c7;
+	border-style: solid;
+	border-width: 1px;
+	padding: 0px 2px 0px 2px;
+	background-color: #e8e8e8;
+	font-family: serif;
+	font-variant: small-caps;
+	font-size: 0.8em;
+}
+.menu {				/* Menu */
+	font-size: 1.0em;
+	font-family: serif;
+	font-style: italic;
+	color: #24225e;
+}
+.path {				/* File path */
+	background-color: #e8e8e8;
+	font-size: 0.9em;
+	font-family: monospace;
 }
 
 a.blog-item {


### PR DESCRIPTION
Adding the various stylings ("menu", "key", "cli"...) of the Haiku-doc.css.

I changed the "button" one to have a wider horizontal padding which makes it
look more like a Haiku button. I plan to use that one in the user guide as
well.