### PR TITLE
minor additions for helping newbies

### DIFF
--- a/content/guides/booting.md
+++ b/content/guides/booting.md
@@ -56,27 +56,33 @@ Adding Haiku to your [GRUB 2](http://www.gnu.org/software/grub/manual/) boot loa
 
 If you previously had only one operating system installed on your computer, GRUB 2 may be configured to wait for the Shift key to be pressed while booting, otherwise no boot menu may be displayed at all, since Haiku is not automatically recognized as a bootable operating system. To force GRUB 2 to always display the selection menu, and to add the Haiku entry in such a way that it will not be removed when the GRUB 2 configuration file is regenerated, perform the following steps:
 
-  * Edit /etc/default/grub and make sure the line `GRUB_HIDDEN_TIMEOUT=0` is commented out.
-  * Edit /etc/grub.d/40_custom and add the following entry
+  * Edit /etc/default/grub and add or uncomment the following option: `GRUB_HIDDEN_TIMEOUT=0`
+  * Edit /etc/grub.d/40_custom and add __one of the following two entries__, depending on your system:
 
 ```
 # for BIOS systems
-menuentry "Haiku R1B1" {
+menuentry "Haiku" {
 	set root=(hd0,3);
 	chainloader +1
 }
 
 # for EFI systems
-menuentry "Haiku R1B1" {
+menuentry "Haiku" {
 	load_video
 	insmod part_msdos
 	insmod chain
-	search --fs-uuid --set=root <your-efi-partition-uuid>
-	chainloader ($root)/<path-to-haiku-loader>
+	search --fs-uuid --set=root <EFIBOOT partition UUID>
+	chainloader ($root)/EFI/BOOT/BOOTX64.EFI
 }
 ```
 
-Of course the partition in the entry (hd0,3) needs to point to the one where you actually installed Haiku. Now you can regenerate the boot menu configuration by issuing `sudo update-grub`
+Of course, the partition in the entries needs to point to the one where you actually installed Haiku. On Linux you can get the `UUID` values of all the partitions and disks in use using the `sudo blkid` and `sudo fdisk -l` commands.
+
+<div class="alert alert-info">The EFI entry above assumes you've created the `EFIBOOT` partition and put the boot loader inside it as explained [on the official guide](/guides/uefi_booting). If you didn't, you need to check the path of the `chainloader` directive and fix accordingly.</div>
+
+On Ubuntu (and other Linux flavors), you can eventually customize more the GRUB setup in a GUI environment using __Grub Customizer__ and following this [getting started tutorial](http://tipsonubuntu.com/2018/03/11/install-grub-customizer-ubuntu-18-04-lts/).
+
+Finally, you can regenerate the boot menu configuration by issuing `sudo update-grub` and reboot.
 
 ### GRUB Legacy (version 0.97 and earlier)
 
@@ -90,6 +96,6 @@ GRUB Legacy differs in the numbering of the partitions compared to GRUB 2, start
 Adding Haiku to your [GRUB Legacy](http://www.gnu.org/software/grub/grub-legacy.en.html) boot loader is as simple as adding a new section to your GRUB menu configuration. After installing Haiku, you will need to boot into your Linux operating system and add the following block of code to your /boot/grub/menu.lst (your mileage may vary, this is the default location however).
 
     # for Haiku
-    title Haiku R1B1
+    title Haiku
     root (hd0,2)
     chainloader +1


### PR DESCRIPTION
I would like to propose a little addition on the guide, after spending a couple of hours yesterday trying to figure out how to configure GRUB. I think that newbies just like me would benefit on having more explicit steps to follow and a link to the official UEFI installation guide.

Changes:

* Example of commands for having UUID data under Linux
* Link to the official UEFI guide and fix the chainloader path accordingly in menuentry
* Installation of Grub Configurer, as it could help newbies
* Removed R1B1 from entries so the guide will be stay forever after (no need to specify version IMHO, hope this is ok)