### PR TITLE
Fix links to the booting guide

### DIFF
--- a/content/guides/installing_haiku_image_disk_partition.html
+++ b/content/guides/installing_haiku_image_disk_partition.html
@@ -28,7 +28,7 @@ dd if=/dev/zero of=haiku.raw bs=1 seek=506 count=4 conv=notrunc</pre>
 
 <h2>Make the partition bootable</h2>
 
-<p>After the image is written to the partition, its <a href="https://en.wikipedia.org/wiki/Volume_boot_record">VBR</a> needs to be modified to make it bootable. You can either use the <code>makebootable</code> program from Haiku, or <a href="/guides/booting/makebootable#makebootabletiny"><code>makebootabletiny</code></a> with Linux.</p>
+<p>After the image is written to the partition, its <a href="https://en.wikipedia.org/wiki/Volume_boot_record">VBR</a> needs to be modified to make it bootable. You can either use the <a href="/guides/booting#makebootable-usage"><code>makebootable</code></a> program from Haiku, or <code>makebootabletiny</code> with Linux.</p>
 
 <p>Assuming that you downloaded <code>makebootabletiny</code>, you need to compile and run it:</p>
 
@@ -37,7 +37,7 @@ dd if=/dev/zero of=haiku.raw bs=1 seek=506 count=4 conv=notrunc</pre>
 
 <h2>Add the partition to your boot manager</h2>
 
-<p>This really depends on which boot manager you are using. For information on how to chain load Haiku from the GRUB 2 and GRUB Legacy boot managers, please see the <a href="/guides/booting/bootmanagers">Configuring GRUB</a> guide.</p>
+<p>This really depends on which boot manager you are using. For information on how to chain load Haiku from the GRUB 2 and GRUB Legacy boot managers, please see the <a href="/guides/booting#grub-2-version-1-96-and-higher">Configuring GRUB</a> guide.</p>
 
 <h2>Set the partition type</h2>
 


### PR DESCRIPTION
Looks like those were not changed after the page was rewritten.