### PR TITLE
Font used on tabs to work on hosts without 'Verdana' font installed

### DIFF
--- a/themes/shijin4/static/css/shijin4.css
+++ b/themes/shijin4/static/css/shijin4.css
@@ -271,7 +271,7 @@ nav.navbar button.btn:hover {
 ul.nav-tabs {
 	font-weight: bold;
 	color: #000;
-	font-family: Verdana;
+	font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
 }
 .tab-content {
 	border: 1px solid #ddd;


### PR DESCRIPTION
The font "Verdana" is not installed on Ubuntu (for example) by default so the tabs are appearing as the default serif fonts on Ubuntu in Firefox which doesn't look too good.  I'm not sure why the tabs on the home page are in Verdana; so this PR changes those to the same fonts as the rest of the page.