### PR TITLE
Update KVM instructions for Ubuntu 18.10 and later

### DIFF
--- a/content/guides/virtualizing/kvm.md
+++ b/content/guides/virtualizing/kvm.md
@@ -32,6 +32,11 @@ If you are using Ubuntu, you can enter the following into the terminal instead a
 sudo apt-get install qemu-kvm libvirt-bin virt-manager
 ```
 
+As of Ubuntu 18.10, the `libvirt-bin` package has been replaced, so the necessary command is a little different:
+```sh
+sudo apt-get install qemu-kvm libvirt-daemon-system libvirt-clients virt-manager
+```
+
 To enable libvirtd on boot, issue the following command into the terminal:
 ```sh
 sudo systemctl enable libvirtd


### PR DESCRIPTION
I noticed that the KVM installation instructions no longer apply to Ubuntu 18.10 and later, so I figured I would update them.