### PR TITLE
GSoC 19: Fix wrong year of GSoC for Btrfs

### DIFF
--- a/content/community/gsoc/2019/ideas.html
+++ b/content/community/gsoc/2019/ideas.html
@@ -371,7 +371,7 @@ available read-only. It is way better for interoperability with other systems
 to be able to write to these disks from Haiku.</p>
 
 <p>The goal of this project is to complete the btrfs filesystem, to allow it
-to write btrfs volumes (reading works already). During GSoC 2016, a student
+to write btrfs volumes (reading works already). During GSoC 2017, a student
 already got as far as creating directories, but it is not possible yet to write
 files. The first part of the work is to review the existing code, and report on
 the current status and the work needed to get everything in place.</p>
@@ -385,7 +385,7 @@ Skill set: kernel, and driver development
 </li>
 <li>Possible mentors/knowledgeable people: PulkoMandy, Sean Healy</li>
 <li><a href="https://git.haiku-os.org/haiku/tree/src/add-ons/kernel/file_systems/btrfs">Sourcecode</a></li>
-<li><a href="https://www.haiku-os.org/blog/hyche">GSoC 2016 log</a></li>
+<li><a href="https://www.haiku-os.org/blog/hyche">GSoC 2017 log</a></li>
 </ul>
 
 


### PR DESCRIPTION
During GSoC 2017 not 2016.