### PR TITLE
Add Russian Telegram group

### DIFF
--- a/content/community/irc/_index.html
+++ b/content/community/irc/_index.html
@@ -80,8 +80,8 @@ language communities have chosen different protocols.</p>
 </li>
 
 <a name="haiku-ru"></a>
-<li><h4>Русскоязычная XMPP конференция</h4>
-<a href="xmpp: haiku-os@conference.jabber.ru?join">haiku-os@conference.jabber.ru</a>
+<li><h4>Русскоязычная группа в Telegram</h4>
+<a href="https://t.me/HaikuOS_RU_chat">t.me/HaikuOS_RU_chat</a>
 </li>
 
 <a name="haiku-se"></a>


### PR DESCRIPTION
This replaces link to XMMP channel which is dead nowadays.