### PR TITLE
News Entry for 2019 Google Code-In Competition

### DIFF
--- a/content/news/2019-11-7_its_almost_time_for_the_2019_google_code-in_and_haiku_is_ready.md
+++ b/content/news/2019-11-7_its_almost_time_for_the_2019_google_code-in_and_haiku_is_ready.md
@@ -1,0 +1,16 @@
++++
+type = "news"
+title = "It's almost time for the 2019 Google Code-In and Haiku is ready!"
+date = "2019-11-07T12:40:00.000Z"
+tags = ["gci", "code-in"]
++++
+
+![GCI 2019](https://www.haiku-os.org/files/GCI-new-logo.jpg "GCI 2019")
+
+Another year, another Google Code-In! The Haiku project is proud to announce that it will be participating in the 2019 Google Code-In!
+
+Together with 28 other open source projects, we'll mentor students between 13 and 17 years of age through a variety of large and small tasks. The aim is to introduce them to the work and community of open source projects, while benefitting ourselves from their work and energy, and maybe even by gaining future contributors.
+
+If you know people in the right age bracket that might be interested, point them to [Google's Code-In site](https://codein.withgoogle.com) that has all the information. 
+
+The contest period starts on the 2nd of December 2019 and will end on the 21st of January 2020. In this time many of the students will flock to the [#haiku IRC channel](https://www.haiku-os.org/community/irc) and the [forums](https://discuss.haiku-os.org). Please give them a warm welcome and support them when you can, thereby also helping our pool of mentors.


### PR DESCRIPTION
I feel it's important for an article like this so students arriving at the Haiku website don't feel lost.

In addition, I saw on the actual Google Code-In website that in our project's description, there's a quote that mentions we are close to approaching our "first beta" when it should really be that we are close to approaching our "second beta".

Finally, I don't know who is in charge of Haiku's Twitter page, however, I feel some sort of announcement should be made in advance soon to show students we are ready to assist them.

I hope this whole comment isn't too crazy.😅