### PR TITLE
adjust year to last year's GSOC

### DIFF
--- a/content/community/gsoc/2020/ideas.html
+++ b/content/community/gsoc/2020/ideas.html
@@ -99,7 +99,7 @@ faster.</p>
 <h4><img src="/images/App_Generic_32.png"/>Improving Haiku's WebKit2 port</h4>
 
 <p>Haiku has a native WebKit port which uses the WebKit1 API. This port is not complete and there are several bugs and minor problems which needs to be fixed.
-The plan is to replace this with a more up to date port based on the WebKit2 API. Based on the work completed in GSoC 2020, WebKit2 on Haiku is now able to render some web pages.
+The plan is to replace this with a more up to date port based on the WebKit2 API. Based on the work completed in GSoC 2019, WebKit2 on Haiku is now able to render some web pages.
 The goal of this project is to continue this work, making the WebKit2 port more reliable, render all pages, handle input events, etc, and make it usable for the WebPositive browser.</p>
 
 <ul>


### PR DESCRIPTION
I think some base work for webkit2 was done during last year's GSoC?