### PR TITLE
Add Windows as build platform using wsl2

### DIFF
--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -36,7 +36,7 @@ Note that in addition to all the platform-specific packages, you will also need 
 | BeOS                               | [pkg](#beos_zeta)    | NO        | Once upon a time... |
 | macOS                              | [Homebrew](#osx)     | NO        | Need a working case sensitive filesystem |
 | Solaris                            | [solaris](#solaris)  | NO        | No longer supported |
-| [Windows](http://microsoft.com)    | [see notes](#windows)| NO        |                     |
+| [Windows](https://microsoft.com/)    | [see notes](#windows)| USING WSL | [Using Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) |
 | Zeta                               | [pkg](#beos_zeta)    | NO        | Once upon a time..  |
 
 <a name="pkgman"></a>
@@ -180,8 +180,7 @@ You can now retry the <code>port install...</code> command in a new Terminal.
 
 It is possible to install Windows Subsystem for Linux and follow the instructions
 for the appropriate Linux distribution (for example, Ubuntu is available this way
-in the Windows store). However, this is currently slower than running Haiku in
-a virtual machine and building from there.
+in the Windows store).
 
 <a name="beos_zeta"></a>
 ## ![beos](/files/os-icons/beos-32.png) BeOS & Zeta


### PR DESCRIPTION
Building Haiku on Windows using Windows Subsystem for Linux version 2 is possible.
Add Windows as an indirectly supported platform through wls2.
Build performance on wsl2 is now close to building from Haiku in a VM (at least on my machine), so removed note of slow performance using wsl1
Corrected microsoft link to use https.