### PR TITLE
Add a dark mode

### DIFF
--- a/themes/shijin4/static/css/shijin4.css
+++ b/themes/shijin4/static/css/shijin4.css
@@ -601,3 +601,74 @@ footer p.last {
 footer a, footer span.glyphicon {
 	color: #FF6C00 !important;
 }
+
+/* dark mode stuff from here on out */
+:root {
+	color-scheme: light dark;
+}
+
+/* bootstrap */
+@media (prefers-color-scheme: dark) {
+	pre {
+		background-color: #202020;
+		color: #CCC;
+	}
+	code {
+		background-color: #202020;
+		color: #CCC;
+	}
+}
+
+/* shinji4.css */
+@media (prefers-color-scheme: dark) {
+	.nav-tabs li {
+		background-color: #1d1d1d;
+		border: 1px solid #111;
+	}
+	.nav-tabs li a:active, .nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus {
+		background-color: #323232;
+		border: 1px solid #111;
+	}
+	.nav-tabs li:hover a {
+		background-color: #424242;
+		border: 1px solid #111;
+	}
+	nav.navbar input.form-control {
+		background: linear-gradient(to bottom, #111 0%,#1c1c1c 100%);
+		color: #AAA;
+		border: 1px solid #d0cbc2 !important;
+	}
+	#activity-tabs .tab-content {
+		background: linear-gradient(to bottom, #111 0%,#1c1c1c 100%);
+		border-color: #222
+	}
+	.panel {
+		background: linear-gradient(to bottom, #111 0%,#1c1c1c 100%);
+		border-color: #222
+	}
+	.panel-default {
+	}
+	#main-front {
+		color: #AAA;
+		background-color: #000;
+	}
+	#main-front a {
+		color: #DDDFFF;
+	}
+	div.node h2 {
+		color: #CCC;
+	}
+	h1, h1.title, h2.title, h2.title a, h3 {
+		color: #CCC !important;
+	}
+	footer {
+		background: linear-gradient(to bottom, #333 0%,#222 100%);
+		border: 1px solid #222;
+		color: #CCC;
+	}
+	span.button {
+		background-color: #333;
+		color: #AAA;
+		border: 1px solid #444;
+	}
+}


### PR DESCRIPTION
this uses the css media query prefers-color-scheme to offer a dark theme to users.
This works in recent versions of safari, chromium (and derivatives) aswell as firefox
(but only with resistfingerprinting off OR a special config flag set)

*NOTE*
This commit has been authored by nephele in #haiku @ freenode
I am merely opening a PR on their request.
Any discussions should be done with nephele directly.