### PR TITLE
docs: Update examples calling configure globally

### DIFF
--- a/content/articles/2015-02-05_building_haiku_mac_os_x_1010_yosemite.html
+++ b/content/articles/2015-02-05_building_haiku_mac_os_x_1010_yosemite.html
@@ -97,7 +97,7 @@ You should get:
 Configure a GCC 2.95 Hybrid, from a non-Haiku platform
 <pre class="terminal">mkdir /Volumes/Haiku/haiku/generated
 cd /Volumes/Haiku/haiku/generated
-../configure --use-xattr --build-cross-tools x86_gcc2 ../../buildtools/ --build-cross-tools x86</pre>
+../configure --use-xattr --cross-tools-source ../../buildtools/ --build-cross-tools x86_gcc2 --build-cross-tools x86</pre>
 <code>./configure</code> has some more options: use <code>./configure --help</code> to list them.
 After some time, you should get:
 <pre class="terminal">binutils and gcc for cross compilation have been built successfully!</pre>

--- a/content/blog/dnivra/2014-05-04_gsoc_2014_arm_port_week_1_and_2.html
+++ b/content/blog/dnivra/2014-05-04_gsoc_2014_arm_port_week_1_and_2.html
@@ -79,7 +79,7 @@ index 6cee1a2..f255a36 100644
 <pre class="terminal">
 $ mkdir generated.arm
 $ cd generated.arm
-$ ../configure --build-cross-tools arm ../../buildtools --include-gpl-addons --include-patented-code --use-gcc-pipe -j2 --bootstrap ../../haikuporter/haikuporter ../../haikuports.cross/ ../../haikuports --target-board beagle
+$ ../configure --cross-tools-source ../../buildtools --build-cross-tools arm --include-gpl-addons --include-patented-code --use-gcc-pipe -j2 --bootstrap ../../haikuporter/haikuporter ../../haikuports.cross/ ../../haikuports --target-board beagle
 $ jam -q @bootstrap-raw
 </pre>
 

--- a/content/blog/krish_iyer/2018-05-06_[gsoc_2018_sdhci_mmc_driver]_week_1_and_2.md
+++ b/content/blog/krish_iyer/2018-05-06_[gsoc_2018_sdhci_mmc_driver]_week_1_and_2.md
@@ -22,7 +22,7 @@ Create a directory where you are going to save the build image and related files
 	mkdir generated.x86_64; cd generated.x86_64
 For compiling
 
-	../configure --build-cross-tools x86_64 ../../buildtools
+	../configure --cross-tools-source ../../buildtools --build-cross-tools x86_64
 
 ## Building Image
 Before building the image you need to install some dependencies

--- a/content/blog/mmu_man/2008-08-03_helping_on_m68k.md
+++ b/content/blog/mmu_man/2008-08-03_helping_on_m68k.md
@@ -24,7 +24,7 @@ There are some other 68k platforms around, like <a href="https://en.wikipedia.or
 
 <h3>Making a build</h3>
 It's not much different from a regular x86 build, the only difference being the target architecture. To get the required tools, just follow the <a href="/documents/dev/building_haiku_on_ubuntu_linux_step_by_step">Linux guide</a>, then when comes the time of configuring, instead we'll do a
-<pre>./configure  --build-cross-tools-gcc4 m68k ../buildtools/</pre>
+<pre>./configure  --cross-tools-source ../buildtools/ --build-cross-tools m68k</pre>
 This should build the cross compiler and set everything up.
 Then just go forward with a
 <pre>jam -q haiku-image</pre>

--- a/content/blog/mmu_man/2016-07-11_story_arcs_and_arch_stories.md
+++ b/content/blog/mmu_man/2016-07-11_story_arcs_and_arch_stories.md
@@ -105,7 +105,7 @@ Buildtools still compile, here's what I use:
 <pre>
 mkdir generated-m68k-gcc4
 cd generated-m68k-gcc4
-../configure --build-cross-tools m68k ../../buildtools --use-xattr --use-gcc-pipe --distro-compatibility official --enable-multiuser --include-gpl-addons --include-patented-code --include-3rdparty --bootstrap ../../../haikuporter/haikuporter/haikuporter ../../../haikuports.cross/haikuports.cross ../../../haikuports/haikuports
+../configure --cross-tools-source ../../buildtools --build-cross-tools m68k --use-xattr --use-gcc-pipe --distro-compatibility official --enable-multiuser --include-gpl-addons --include-patented-code --include-3rdparty --bootstrap ../../../haikuporter/haikuporter/haikuporter ../../../haikuports.cross/haikuports.cross ../../../haikuports/haikuports
 </pre>
 
 I also built GDB from the 7.8 stock sources although I'm not sure I'll use it:

--- a/content/documents/dev/building_haiku_ubuntu_linux_step_step.md
+++ b/content/documents/dev/building_haiku_ubuntu_linux_step_step.md
@@ -39,12 +39,12 @@ the build tools (be sure to adjust the options to match your build environment):
 **Working in a clean build directory:**
 ```sh
 mkdir generated.x86_64; cd generated.x86_64
-../configure --build-cross-tools x86_64 ../../buildtools
+../configure --cross-tools-source ../../buildtools --build-cross-tools x86_64
 ```
 
 **Working in the top level:**
 ```sh
-./configure --build-cross-tools x86_64 ../buildtools
+./configure --cross-tools-source ../buildtools --build-cross-tools x86_64
 ```
 
 x86_64 Haiku Builds

--- a/content/documents/dev/getting_linux_developer_tools.html
+++ b/content/documents/dev/getting_linux_developer_tools.html
@@ -54,11 +54,11 @@ tags = ["obsolete"]
 
 <p>2.95:<br /></p>
 
-<pre>cd haiku <br />./configure --build-cross-tools ../buildtools/</pre>
+<pre>cd haiku <br />./configure --cross-tools-source ../buildtools/ --build-cross-tools x86_gcc2</pre>
 
 <p>4.x</p>
 
-<pre>cd haiku<br />./configure   --build-cross-tools-gcc4 x86 ../buildtools/</pre>
+<pre>cd haiku<br />./configure --cross-tools-source ../buildtools/ --build-cross-tools x86</pre>
 
 <p>The process can take quite some time, but when it finishes you are ready to compile your first haiku image.<br /></p>
         </div>

--- a/content/guides/building/compiling-arm.md
+++ b/content/guides/building/compiling-arm.md
@@ -17,7 +17,7 @@ Building the ARM compiler toolchain is quite easy using Haiku's ```configure``` 
 
 1. Perform a git clone haiku and buildtools
 2. Within the haiku source directory, create your workspace for ARM via ```mkdir generated.arm; cd generated.arm```
-2. Leverage configure to build your ARM toolchain. ```../configure -j2 --build-cross-tools arm ../../buildtools```
+2. Leverage configure to build your ARM toolchain. ```../configure -j2 --cross-tools-source ../../buildtools --build-cross-tools arm```
 
 ## Building an MMC (SD Card) Image
 

--- a/content/guides/building/compiling-powerpc.md
+++ b/content/guides/building/compiling-powerpc.md
@@ -8,7 +8,7 @@ tags = ["PowerPC compiling"]
 <h3>PowerPC Compiler Toolset</h3>
 <p>Building the PowerPC compiler toolset is quite easy and involves generating gcc binaries for your platform. For a complete list of flags for the configure script, see <a href='/guides/building/configure'>Haiku's Configure Options</a></p>
 <p>From the haiku source directory, run the following. (be sure to adjust the options to match your build environment.)
-<pre class="terminal">./configure --build-cross-tools ppc ../buildtools</pre></p>
+<pre class="terminal">./configure --cross-tools-source ../buildtools --build-cross-tools ppc</pre></p>
 
 <p>If you want to run configure again to tweak some more options, you need to tell it to configure for PowerPC. This is done with the --cross-tools-prefix option:
 <pre class="terminal">../configure --use-gcc-pipe --cross-tools-prefix cross-tools/bin/ppc-unknown-haiku-

--- a/content/guides/building/compiling-sparc.md
+++ b/content/guides/building/compiling-sparc.md
@@ -17,7 +17,7 @@ Building the SPARC compiler toolchain is quite easy using Haiku's ```configure``
 
 1. Perform a git clone haiku and buildtools
 2. Within the haiku source directory, create your workspace for SPARC via ```mkdir generated.sparc; cd generated.sparc```
-2. Run configure to build your SPARC toolchain. ```../configure --use-gcc-pipe -j4 --build-cross-tools sparc ../../buildtools```
+2. Run configure to build your SPARC toolchain. ```../configure --use-gcc-pipe -j4 --cross-tools-source ../../buildtools --build-cross-tools sparc```
 
 ## Building a filesystem image
 

--- a/content/guides/building/compiling-x86.md
+++ b/content/guides/building/compiling-x86.md
@@ -33,7 +33,7 @@ binaries for your platform. For a complete list of flags for the configure
 script, see <a href='/guides/building/configure'>Haiku's Configure Options</a>
 
 ```sh
-./configure --build-cross-tools x86_gcc2 ../buildtools --build-cross-tools x86
+./configure --cross-tools-source ../buildtools --build-cross-tools x86_gcc2 --build-cross-tools x86
 ```
 
 <h3>Compiling raw nightly disk images</h3>

--- a/content/guides/building/compiling-x86_64.md
+++ b/content/guides/building/compiling-x86_64.md
@@ -21,12 +21,12 @@ the build tools (be sure to adjust the options to match your build environment):
 **Working in a clean build directory:**
 ```sh
 mkdir generated.x86_64; cd generated.x86_64
-../configure --build-cross-tools x86_64 ../../buildtools
+../configure --cross-tools-source ../../buildtools --build-cross-tools x86_64
 ```
 
 **Working in the top level:**
 ```sh
-./configure --build-cross-tools x86_64 ../buildtools
+./configure --cross-tools-source ../buildtools --build-cross-tools x86_64
 ```
 
 x86_64 Haiku Builds

--- a/content/guides/building/configure/_index.html
+++ b/content/guides/building/configure/_index.html
@@ -8,12 +8,16 @@ tags = []
 As of February 2010, Haiku's `configure` has several interesting options.  These options are briefly explained by running `configure --help` on the command line.  Below, additional information will be discussed as a complement to the usage output text.
 
 <ul>
-<li><h4>--build-cross-tools &lt;arch&gt; &lt;build tools dir&gt;</h4>
-Compile the build tools for one of the following &lt;arch&gt; [x86|x86_gcc2|x86_64|ppc|arm|m68k|mips]. "x86_gcc2" will build gcc2 build tools. Using gcc2 is only a concern if you require binary compatibility with BeOS. All other architectures use gcc7. To build a supported hybrid combination you can repeat the --build-cross-tools for the secondary architecture, but without a &lt;build tools dir&gt;. A note about <a href="#buildtoolsdir">&lt;build tools dir&gt;</a>.
-</li>
+<li><h4>--build-cross-tools &lt;arch&gt;</h4>
+Compile the build tools for one of the following &lt;arch&gt; [x86|x86_gcc2|x86_64|ppc|arm|m68k|mips]. "x86_gcc2" will build gcc2 build tools. Using gcc2 is only a concern if you require binary compatibility with BeOS. All other architectures use gcc7. To build a supported hybrid combination you can repeat the --build-cross-tools for the secondary/additional architectures. Be sure to specify <code>--cross-tools-source</code> when using these flags.
+</li
 
 <li><h4>--cross-tools-prefix &lt;prefix&gt;</h4>
 Point to pre-built binaries of the build tools. This can be used after the cross-tools have been compiled with a previous <code>configure --build-cross-tools ...</code>. The option can be repeated to specify the secondary build tools for a Hybrid.
+</li>
+
+<li><h4>--cross-tools-source &lt;build tools dir&gt;</h4>
+Point to the buildtools (toolchain source code) for Haiku. This only needs specified once when using </code>--build-cross-tools</code>. A note about <a href="#buildtoolsdir">&lt;build tools dir&gt;</a>.
 </li>
 
 <li><h4>--distro-compatibility &lt;level&gt;</h4>

--- a/content/guides/building/configure/different-generated.md
+++ b/content/guides/building/configure/different-generated.md
@@ -24,7 +24,7 @@ tags = []
 
 <pre class="terminal">
 cd /path/haiku/haiku/generated.x86_gcc2/
-../configure --build-cross-tools x86_gcc2 ../../buildtools
+../configure --cross-tools-source ../../buildtools --build-cross-tools x86_gcc2
 jam -q @alpha-raw
 </pre>
 

--- a/content/guides/building/gcc-hybrid.md
+++ b/content/guides/building/gcc-hybrid.md
@@ -63,7 +63,7 @@ Be sure to consult the various <a href="/guides/building/configure">configure op
 
 ```sh
   cd generated.x86gcc2
-  ../configure --build-cross-tools x86_gcc2 ../../buildtools/ --build-cross-tools x86
+  ../configure --cross-tools-source ../../buildtools/ --build-cross-tools x86_gcc2 --build-cross-tools x86
 ```
 
 <h3>Jamming inside one of the generated folders</h3>


### PR DESCRIPTION
* Updates all website documentation inline with
  https://review.haiku-os.org/c/haiku/+/3206
* Shall only be merged after 3206 is merged.
* Also updates some random outdated blog posts and
  aligns them under our current configure design.