### PR TITLE
Sound contest: clarification and re-ordering

### DIFF
--- a/content/news/2020-09-11-system-sound-contest.md
+++ b/content/news/2020-09-11-system-sound-contest.md
@@ -10,16 +10,17 @@ It wouldn't be wrong to say that, Haiku is a unique operating system. It takes i
 
 As R1 steadily approaches, we are looking for contestants (amateur, professional, enthusiast) to produce system sound effects for Haiku. Specifically sounds for:
 
-**Errors:**
+**General:**
 
 - Beep
-- Error notification
+- A nice and soothing startup chime
 
 **Notifications:**
 
-- Important notification
 - Information notification
-- Progress notification
+- Important notification
+- Error notification
+- Progress notification (= the percentage of the progress bar gets updated)
 
 **Key/mouse events:**
 
@@ -36,10 +37,8 @@ As R1 steadily approaches, we are looking for contestants (amateur, professional
 - Window close
 - Window minimised
 - Window open
-- Window restored
-- Window zoomed
-
-- In addition to these above, a nice soothing **startup chime**
+- Window restored (= gets 'unminimised')
+- Window zoomed (= when 'zoom' button (right widget in tab) is clicked)
 
 ## Contest guidelines
 


### PR DESCRIPTION
* Added clarifications where the sound description may not be clear enough.
* Renamed 'Error' category to 'General' and moved the start chime there.
  The 'Beep' isn't necessarily a sign of error, it can be used for various things.
* Re-ordered the notifications according to their severity.