### PR TITLE
Improve visibility of table headers in dark theme.

### DIFF
--- a/themes/shijin4/static/css/shijin4.css
+++ b/themes/shijin4/static/css/shijin4.css
@@ -655,6 +655,10 @@ footer a, footer span.glyphicon {
 	#main-front a {
 		color: #DDDFFF;
 	}
+	div.node table th {
+		color: #CCC;
+		background-color: #333;
+	}
 	div.node h2 {
 		color: #CCC;
 	}


### PR DESCRIPTION
Affects, e.g., https://www.haiku-os.org/guides/building/port_status/ - which includes a table with header.