### PR TITLE
PortStatus: Update URLs for platform-specific info

### DIFF
--- a/content/guides/building/port_status.html
+++ b/content/guides/building/port_status.html
@@ -17,7 +17,7 @@ real-world developer interest.<br/><br/>
 <tr><td>32-bit x86 PC</td><td>High</td><td>x86</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td>Stable</td></tr>
 <tr><td>64-bit x86 PC</td><td>High</td><td>x86_64</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td>Production</td></tr>
 
-<tr><td COLSPAN=7><h3>ARM (Tier 2)</h3>Newly revitalized line of processors excelling at low power consumption and low cost. See <a href="https://cgit.haiku-os.org/haiku/tree/docs/develop/ports/arm">platform-specific notes</a> in the source tree.</td></tr>
+<tr><td COLSPAN=7><h3>ARM (Tier 2)</h3>Newly revitalized line of processors excelling at low power consumption and low cost. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/arm">platform-specific notes</a> in the source tree.</td></tr>
 <tr><th>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
 <tr><td><a href="http://beagleboard.org" title="BeagleBoard">BeagleBoard</a> Black</td><td>Moderate</td><td>beagle</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>20%</td></tr>
 <tr><td><a href="http://www.cubieboard.org/">Cubieboard 4</a></td><td>Moderate</td><td>cubieboard4</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
@@ -32,14 +32,14 @@ real-world developer interest.<br/><br/>
 <tr><td>Genesi <a href="http://www.genesi-tech.com/products/efika">Efika MX</a></td>
 	<td>Moderate</td><td>???</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
 
-<tr><td COLSPAN=7><h3>PowerPC (Tier 2)</h3>Previous challenger to the x86 market in desktop and laptop computers. See <a href="https://cgit.haiku-os.org/haiku/tree/docs/develop/ports/ppc">platform-specific notes</a> in the source tree.</td></tr>
+<tr><td COLSPAN=7><h3>PowerPC (Tier 2)</h3>Previous challenger to the x86 market in desktop and laptop computers. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/ppc">platform-specific notes</a> in the source tree.</td></tr>
 <tr><th>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
 <tr><td>Genesi Efika I & II</td><td>Low</td><td>ppc</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td><td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td><td>80%</td></tr>
 <tr><td>Apple G3/G4</td><td>Low</td><td>ppc</td><td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td><td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
 <tr><td>ACube Sam460ex</td><td>High</td><td>ppc</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
 <tr><td>BeBox</td><td>None</td><td>ppc</td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>0%</td></tr>
 
-<tr><td COLSPAN=7><h3>Sparc (Tier 2)</h3>Open, royalty-free CPU architecture, historically with several manufacturers. Well documented and clean hardware. See <a href="https://cgit.haiku-os.org/haiku/tree/docs/develop/ports/sparc">platform-specific notes</a> in the source tree.</td></tr>
+<tr><td COLSPAN=7><h3>Sparc (Tier 2)</h3>Open, royalty-free CPU architecture, historically with several manufacturers. Well documented and clean hardware. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/sparc">platform-specific notes</a> in the source tree.</td></tr>
 <tr><th>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
 <tr><td>Sun Ultra 60</td><td>Low</td><td>sparc</td>
 	<td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td>
@@ -52,7 +52,7 @@ real-world developer interest.<br/><br/>
 	<td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td>
 	<td>15%</td></tr>
 
-<tr><td COLSPAN=7><h3>m68k (Tier 3)</h3>Classic home computer devices. See <a href="https://cgit.haiku-os.org/haiku/tree/docs/develop/ports/m68k">platform-specific notes</a> in the source tree.</td></tr>
+<tr><td COLSPAN=7><h3>m68k (Tier 3)</h3>Classic home computer devices. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/m68k">platform-specific notes</a> in the source tree.</td></tr>
 <tr><th>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
 <tr><td>Atari TT</td><td>Low</td><td>m68k</td>
 	<td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td>


### PR DESCRIPTION
This points to the correct respective directories containing architecture-specific notes under the kernel docs in the tree, on the current Haiku git web service.
Eliminates a handful of 404s.