### PR TITLE
Show all the posts from a blog in its list

### DIFF
--- a/themes/shijin4/layouts/blog/list.html
+++ b/themes/shijin4/layouts/blog/list.html
@@ -9,7 +9,7 @@
 
 		<div class="col-md-9">
 		{{- if (isset .Params "author") -}}
-			{{ $paginator := .Paginate (where .Site.RegularPages ".Params.author" "==" .Params.author) }}
+			{{ $paginator := .Paginate .RegularPages }}
 
 			{{- range $paginator.Pages -}}
 				{{ .Render "summary" }}

--- a/themes/shijin4/layouts/blog/single.html
+++ b/themes/shijin4/layouts/blog/single.html
@@ -6,7 +6,7 @@
 			<div class="node">
 				<h1 class="title">{{ .Title }}</h1>
 				<div class="meta">
-					Blog post by <a href="/blog/{{ lower .Params.author }}/">{{ .Params.author }}</a> on {{ .Date.Format "Mon, 2006-01-02 15:04" }}
+					Blog post by <a href="{{ .Parent.RelPermalink }}">{{ .Params.author }}</a> on {{ .Date.Format "Mon, 2006-01-02 15:04" }}
 						{{ if .Params.tags }}
 						<div class="terms">
 						{{ range $i, $e := .Params.tags }}{{if $i}}, {{end}}

--- a/themes/shijin4/layouts/blog/summary.html
+++ b/themes/shijin4/layouts/blog/summary.html
@@ -14,7 +14,7 @@
 	<p>{{ .Summary }}</p>
 	<div class="links">
 		{{ if (isset .Params "author") }}
-			<a class="blog-item" href="/blog/{{ lower .Params.author }}/">{{ .Params.author }}'s blog</a>
+			<a class="blog-item" href="{{ .Parent.RelPermalink }}">{{ .Parent.Params.title }}</a>
 		{{ end }}
 		<a class="readmore-item" href="{{ .Permalink }}">Read More</a>
 	</div>


### PR DESCRIPTION
Currently /blog/\<blogname\>/ is somewhat of a mix of things. It shows all the site posts with the same author as that in /blog/\<blogname\>/_index.md. That means:
1. You only get the list for created blogs. No articles from people without their blog section.
2. (Consequence of 1) You don't get articles with variation in the author property (pawel_dziepak vs paweł_dziepak, pulkomandy vs PulkoMandy, etc)
3. You get posts from all sections, not only the blog one.

Given the URL prefix, 1 seems reasonable but 2 and 3 not so much. Now, if /blog/\<blogname\>/ is to be seen as an author and not a blog entry point, then 3 is a feature and this change can be rejected on the spot, preferring other solutions.