### PR TITLE
News: Remove duplicate sound set entry

### DIFF
--- a/content/news/2020-12-07-contest-results.md
+++ b/content/news/2020-12-07-contest-results.md
@@ -64,10 +64,6 @@ According to votes, the final scores were calculated as below:
     <td>23</td>
     </tr>
     <tr>
-    <td>7. Leafy</td>
-    <td>23</td>
-    </tr>
-    <tr>
     <td>8. Forest Dreams</td>
     <td>23</td>
     </tr>


### PR DESCRIPTION
The "System Sounds Contest Wrap-up" news article had a duplicate entry in the results table.