### PR TITLE
Automatic year update

### DIFF
--- a/static/js/donationchart.js
+++ b/static/js/donationchart.js
@@ -88,6 +88,8 @@ function updateDonationMeter() {
 				var month = monthToName[updatedAt.getMonth()];
 				var updated = document.getElementById("fundraising-updated");
 				updated.innerText = month + " " + formatDay(updatedAt.getDate());
+				document.getElementById("fundraising-year").innerText =
+					updatedAt.getFullYear();
 
 				// 4. The EUR to USD rate
 				var eurToUsd = document.getElementById("fundraising-eur-to-usd");

--- a/themes/shijin4/layouts/blog/rss.xml
+++ b/themes/shijin4/layouts/blog/rss.xml
@@ -4,7 +4,7 @@
 	<link>{{ .Permalink }}</link>
 	<language>en-US</language>
 	<author>Haiku, Inc.</author>
-	<rights>(C) 2001-2020 Haiku, Inc. All rights reserved.</rights>
+	<rights>(C) 2001-{{ now.Format "2006" }} Haiku, Inc. All rights reserved.</rights>
 	<updated>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</updated>
 	{{- range first 15 (where (where .Site.RegularPages.ByDate.Reverse "Type" "blog") ".Params.date" "!=" nil) -}}
 		{{ partial "item.xml" . }}

--- a/themes/shijin4/layouts/partials/footer.copyright.html
+++ b/themes/shijin4/layouts/partials/footer.copyright.html
@@ -1,4 +1,4 @@
 <footer>
-	<p>&copy; 2001-2020 Haiku, Inc. &mdash; Haiku&reg; and the HAIKU logo&reg; are registered trademarks of <a href="http://www.haiku-inc.org" target="_blank">Haiku, Inc.</a></p>
+	<p>&copy; 2001-{{ now.Format "2006" }} Haiku, Inc. &mdash; Haiku&reg; and the HAIKU logo&reg; are registered trademarks of <a href="http://www.haiku-inc.org" target="_blank">Haiku, Inc.</a></p>
 	<p class="last"><a href="/index.xml">Main feed</a> | <a href="/blog/index.xml">Blog-O-Sphere feed</a></p>
 </footer>

--- a/themes/shijin4/layouts/partials/fundraising.html
+++ b/themes/shijin4/layouts/partials/fundraising.html
@@ -66,7 +66,7 @@
 }
 </style>
 
-<h2 class="fundraising">Fundraising 2020</h2>
+<h2 class="fundraising">Fundraising <span id="fundraising-year"></span></h2>
 <div class="content">
   <div style="margin-top: 36px;">
     <div class="fundraising-meter">

--- a/themes/shijin4/layouts/partials/meta.html
+++ b/themes/shijin4/layouts/partials/meta.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	{{ if .Description }}<meta name="description" content="{{ .Description }}">{{ end }}
 	{{ if isset .Params "tags" }}<meta name="keywords" content="{{ delimit .Params.tags "," }}">{{ end }}
-	<meta name="copyright" content="2001-2020 Haiku Inc.">
+	<meta name="copyright" content="2001-{{ now.Format "2006" }} Haiku Inc.">
 	<meta property="og:site_name" content="{{ .Site.Title }}">
 	<meta property="og:title" content="{{ .Title }}">
 	<meta property="og:url" content="{{ .Permalink }}">

--- a/themes/shijin4/layouts/rss.xml
+++ b/themes/shijin4/layouts/rss.xml
@@ -4,7 +4,7 @@
 	<link>{{ .Permalink }}</link>
 	<language>en-US</language>
 	<author>Haiku Inc.</author>
-	<rights>(C) 2001-2020 Haiku, Inc. All rights reserved.</rights>
+	<rights>(C) 2001-{{ now.Format "2006" }} Haiku, Inc. All rights reserved.</rights>
 	<updated>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</updated>
 	{{ range first 15 (where .Site.RegularPages "Type" "!=" "article") }}
 		{{ partial "item.xml" . }}


### PR DESCRIPTION
There's still the copyright line in config.toml, that can't be programmatic, AFAIK.
For the donation chart I'm assuming "calendar years" are used, and not May 4th 2020 - May 3rd 2021 or whatever. The financial reports seem to agree, but someone please confirm before applying change.