### PR TITLE
FOSDEM event: fix year in title (not 2020)

### DIFF
--- a/content/conference/2021_fosdem_2021.md
+++ b/content/conference/2021_fosdem_2021.md
@@ -1,6 +1,6 @@
 +++
 type = "conference"
-title = "FOSDEM 2020 and coding sprint"
+title = "FOSDEM 2021"
 date = "2021-01-16T07:00:00.000Z"
 tags = []
 [event]


### PR DESCRIPTION
And we don't have a coding sprint (unless someone wants to make one?)