### PR TITLE
General cleanup

### DIFF
--- a/content/blog/jt15s/2020-12-31_hello_from_the_haiku_promotion_team.md
+++ b/content/blog/jt15s/2020-12-31_hello_from_the_haiku_promotion_team.md
@@ -60,6 +60,8 @@ We aim to attract more research groups by promoting the uses of Haiku for resear
 
 Additionally, we have participated in [Google Summer of Code](https://summerofcode.withgoogle.com/) and [Google Code-In](https://codein.withgoogle.com/) (when it was still operating), providing opportunities for students to contribute to our project and develop their coding skills. We also participated in the [Semester of Code](http://semesterofcode.com/) but unfortunately we didn't receive any student applications. 
 
+We aim to attract more research groups by promoting the uses of Haiku for research, and we also want to reach out to Auckland University and see if their UI research group is interested in coming back to Haiku to conduct any future research.
+
 ### Businesses
 Businesses can benefit from Haiku as an operating system, and personally, I see Haiku as a lightweight alternative to the proprietary desktop operating systems businesses currently use. 
 

--- a/content/community/gsoc/2021/ideas.html
+++ b/content/community/gsoc/2021/ideas.html
@@ -15,12 +15,14 @@ For details about how to apply, please check out <a href="/community/gsoc/2021/s
 The following list represents some of our ideas and wishes for the project. However, suggesting your own idea is always encouraged!</p>
 </div>
 
+<div class="alert alert-warning">
 <p>Be aware: API design and kernel-related work requires a higher level of skill, and
 user interface design usually involves a lot more thought than other work. A
 significantly more convincing proposal is required for tasks involving those.
 Getting started with the design early (before the application period ends) is
 recommended, to maximize your chances of being selected, and allow a larger part
 of the coding period dedicated to coding tasks.</p>
+</div>
 
 <p>If you find one of the "big" ideas interesting, but feel that you cannot
 complete it within the allotted coding time, feel free to suggest splitting it
@@ -30,7 +32,7 @@ into smaller parts for your proposal.</p>
 other accepted mentoring organizations must coordinate with both Haiku and the
 other mentoring organization beforehand.</p>
 
-<h3>Project Areas</h3>
+<h2>Project Areas</h2>
 
 <ul>
 <li><a href="#applications">Applications</a></li>
@@ -44,10 +46,10 @@ other mentoring organization beforehand.</p>
 </ul>
 
 <a id="applications" name="applications"></a>
-<h3>Applications</h3>
+<h2>Applications</h2>
 
 <!-- on hold until webkit2 is ready, there's little point otherwise
-<h4><img src="/images/App_Generic_32.png"/>Updating and Extending WebPositive</h4>
+<h3><img src="/images/App_Generic_32.png"/>Updating and Extending WebPositive</h3>
 <p>
 Haiku uses a WebKit based browser called WebPositive. The browser is still quite
 simple and can be improved in multiple ways. Some of the missing features are:
@@ -70,33 +72,33 @@ add-ons system.</li>
 -->
 
 
-<h4><img src="/images/App_Generic_32.png"/>Improving Haiku's WebKit2 port</h4>
+<h3><img src="/images/App_Generic_32.png"/>Improving Haiku's WebKit2 port</h3>
 
-<h5>Idea description</h5>
+<h4>Idea description</h4>
 
 <p>Haiku has a native WebKit port which uses the WebKit1 API. This port is not complete and there are several bugs and minor problems which need to be fixed.
 The plan is to replace this with a more up to date port based on the WebKit2 API. Based on the work completed in GSoC 2019, WebKit2 on Haiku is now able to render some web pages.
 The goal of this project is to continue this work, making the WebKit2 port more reliable, render all pages, handle input events, etc, and make it usable for the WebPositive browser.</p>
 
-<h5>Why we need this</h5>
+<h4>Why we need this</h4>
 
 <p>The web browser is an important part of the operating system today. It is difficult to attract and retain users if we don't provide a good web browser.
 When we started our efforts with WebKit, WebKit2 wasn't ready for our use yet, but today it is more mature and it is time to migrate to it.</p>
 
-<h5>Further reading</h5>
+<h4>Further reading</h4>
 
 <ul>
 <li>Skill set: userland development, exploring a large code-base (WebCore)</li>
 <li>Possible mentors/knowledgeable people: PulkoMandy</li>
-<li><a href="https://github.com/haiku/haikuwebkit/pull/4">Sourcecode of GSoC 2019 work</a></li>
+<li><a href="https://github.com/haiku/webkit">Sourcecode (see the webkit2 branch)</a></li>
 <li><a href="https://www.haiku-os.org/blog/rajagopalan">GSoC 2019 blog</a></li>
 <li><a href="https://dev.haiku-os.org/query?status=assigned&status=in-progress&status=new&status=reopened&component=%5EApplications%2FWebPositive">Opened tickets</a></li>
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>Better XMPP instant messaging client for Haiku</h4>
+<h3><img src="/images/App_Generic_32.png"/>Better XMPP instant messaging client for Haiku</h3>
 
-<h5>Idea description</h5>
+<h4>Idea description</h4>
 
 <p>XMPP is a modern communication protocol for instant messaging. It has open standards and several free software client and server implementations.</p>
 <p>Currently, the available native clients for Haiku are quite simple and don't even allow to replace all IRC features. The goal of this project is
@@ -104,7 +106,7 @@ to improve <a href="https://github.com/haikuarchives/renga">Renga</a>, one of su
 <p>The main features to implement are more complete support for multi-user chat (in particular, moderation aspects, allowing to manage channel permissions, kick and ban users, etc)
 as well as any other feature considered useful: activity notification, pictures and file sharing, whiteboard collaboration, …</p>
 
-<h5>Why we need this</h5>
+<h4>Why we need this</h4>
 
 <p>Most of Haiku communication channels are currently hosted on IRC servers. IRC is a
 simple protocol, but it lacks modern features and is difficult to use from unstable connections or using mobile phones.
@@ -112,7 +114,7 @@ As a result, IRC is less popular, and a part of the Haiku community doesn't use 
 <p>Since we prefer to support open source software and usage of Haiku, XMPP is a good candidate, if we can have a working native client allowing to use it.
 We don't want people to instead use closed-source software or undocumented protocols.</p>
 
-<h5>Further reading</h5>
+<h4>Further reading</h4>
 
 <ul>
 	<li>Skill set: userland development, user interface design</li>
@@ -120,9 +122,9 @@ We don't want people to instead use closed-source software or undocumented proto
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>VirtualBox port to Haiku</h4>
+<h3><img src="/images/App_Generic_32.png"/>VirtualBox port to Haiku</h3>
 
-<p>VirtualBox is a virtual machine allowing to run an operating system inside of another. Porting it to Haiku would allow Haiku users to run another system, such as Windows or Linux, when they need to run an application that is not yet available for Haiku. This would make using Haiku as their primary operating system a viable approach for more people.</p>
+<p>VirtualBox is a virtual machine that allows users to run an operating system inside of another. Porting it to Haiku would allow Haiku users to run another system, such as Windows or Linux, when they need to run an application that is not yet available for Haiku. This would make using Haiku as their primary operating system a viable approach for more people.</p>
 
 <p>Starting from <a href="http://article.gmane.org/gmane.comp.emulators.virtualbox.devel/3384">this preliminary work</a>, continue and complete the port. This includes writing a native GUI for VirtualBox, getting it to run, and more importantly, work on the virtualization driver which will allow virtualbox to run the emulated machine using the native CPU. This makes the emulated system run at close-to-native speed, whereas a software emulation would be unbearably slow.</p>
 
@@ -130,7 +132,7 @@ We don't want people to instead use closed-source software or undocumented proto
 <li>Possible mentors/knowledgeable people: mmu_man</li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>Hardware acceleration for Haiku's QEMU port</h4>
+<h3><img src="/images/App_Generic_32.png"/>Hardware acceleration for Haiku's QEMU port</h3>
 
 <p>QEMU is a virtual machine which allows running an operating system inside of another. While there already is a Haiku port, it currently does not support any acceleration system through native virtualization (through Intel VT-x and AMD SVM.) This makes it too slow for many uses. Fixing this would allow Haiku users to run another system, such as Windows or Linux, when they need to run an application that is not yet available for Haiku. This would make using Haiku as their primary operating system a viable approach for more people.</p>
 
@@ -144,9 +146,7 @@ We don't want people to instead use closed-source software or undocumented proto
 <li><a href="https://nxr.netbsd.org/xref/src/sys/dev/nvmm/">NVMM Sourcecode</a></li>
 </ul>
 
-<h4><img src="/images/Prefs_Devices.png"/>
-Devices preferences/Hardware manager
-</h4>
+<h3><img src="/images/Prefs_Devices.png"/>Device Preferences/Hardware Manager</h3>
 <p>Haiku is meant to be an easy to use graphical operating system. It should
 provide a GUI to manage devices and drivers. This is currently implemented in
 the "Devices" preferences, however it does little more than listing devices
@@ -154,7 +154,7 @@ found on the machine.</p>
 <p>The goal of this project is to extend the functionality of Devices preferences
 to make it a more complete and useful tool. This includes working on the following features:
 <ul>
-<li>Telling wether a driver is loaded for a given device and where the matching /dev entry is</li>
+<li>Telling whether a driver is loaded for a given device and where the matching /dev entry is</li>
 <li>Giving user readable information on the device type and subtype</li>
 <li>Allowing to blacklist/disable the driver for a given device</li>
 <li>Support for USB and bluetooth devices (currently not listed at all)</li>
@@ -171,15 +171,15 @@ building the GUI itself.</p>
 	<li>Existing code: <a href="https://cgit.haiku-os.org/haiku/tree/src/apps/devices">"Devices"</a></li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>Other applications</h4>
-<p>There are many open source 3rd party applications for Haiku that could use improvements. Whether it is resolving bugs, adding features, updating the coding style, updating them to use the Locale and Layout Kits, or anything else imaginable! Writing applications from scratch is also possible.</p>
+<h3><img src="/images/App_Generic_32.png"/>Other applications</h3>
+<p>There are many open source 3rd party applications for Haiku that could use improvements. Whether it is resolving bugs, adding features, updating the coding style, updating them to use the Locale and Layout Kits, or anything else imaginable, working on third party applications for Haiku is an often-overlooked aspect of the Project. Writing applications from scratch or porting applications you may already have written for other platforms is also a good idea.</p>
 
 <ul>
 <li><a href="https://github.com/Barrett17/Caya">Caya</a> (IM client)</li>
 <li><a href="https://github.com/HaikuArchives/Torrentor">Torrentor!</a></li>
 <li><a href="https://github.com/HaikuArchives/Calendar">Calendar</a></li>
-<li><a href="https://github.com/HaikuArchives">Many applications at HaikuArchives</a></li>
-<li><a href="http://pulkomandy.tk/~beosarchive/">Lots of abandonned projects for BeOS looking for a maintainer</a></li>
+<li><a href="https://github.com/HaikuArchives">Applications at HaikuArchives</a></li>
+<li><a href="http://pulkomandy.tk/~beosarchive/">Lots of abandoned projects for BeOS looking for a maintainer</a></li>
 </ul>
 <ul><li>
 Skill set: userland development, user interface design, exploring an existing code base, others depending on the application retained.
@@ -191,11 +191,9 @@ Skill set: userland development, user interface design, exploring an existing co
 <a id="drivers" name="drivers"></a>
 <h3>Drivers</h3>
 
-<h4><img src="/images/Prefs_Devices.png"/>
-	Improving intel video driver
-</h4>
+<h3><img src="/images/Prefs_Devices.png"/>Improving Intel video drivers</h3>
 
-<p>Haiku comes with a video driver for intel chipsets. However, on many supposedly supported devices, the driver will
+<p>Haiku comes with a video driver for Intel chipsets. However, on many supposedly supported devices, the driver will
 only produce a black screen with no output, confusing users and forcing them to fallback to VESA video modes.
 </p>
 <p>The goal of this project is to improve the driver and fix the different problems, making sure we get video output
@@ -207,9 +205,9 @@ between generations are, and which part the driver is currently not properly imp
 	<li>Possible mentors/knowledgeable people: PulkoMandy, waddlesplash</li>
 </ul>
 
-<h4><img src="/images/Prefs_Devices.png"/>
+<h3><img src="/images/Prefs_Devices.png"/>
 USB Support for FreeBSD network compatibility layer
-</h4>
+</h3>
 
 <p>Haiku uses a FreeBSD network compatibility layer to support many network devices (ethernet and wireless) using drivers written for the FreeBSD project. This allows reusing network drivers with very little changes, considerably decreasing the effort needed to get good hardware support in Haiku.</p>
 <p>However, this layer only supports PCI devices, and doesn't work with USB ones. Adding support for USB to the compatibility layer would bring us support for a range of devices like so-called USB tethering, as well as USB to Ethernet and WiFi dongles.</p>
@@ -226,9 +224,9 @@ USB Support for FreeBSD network compatibility layer
 
 <!-- USB isochronous appears to work well enough, to be revisited with more focus
 	on the webcam and audio drivers
-<h4><img src="/images/webcam.png"/>
+<h3><img src="/images/webcam.png"/>
 Isochronous USB transfers (USB Webcam &amp; soundcard support)
-</h4>
+</h3>
 <p>Currently Haiku has very limited support for webcams and USB sound cards.
 The goal of this task is to improve the WebCam or USB audio drivers, in order
 to make them production ready. For both of these, the USB specification has a
@@ -259,9 +257,9 @@ may also need some work to get everything running smoothly.</p>
 
 
 <!-- Mentors wanted
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 ACPI Video Extensions
-</h4>
+</h3>
 
 <p>ACPI Video Extensions, as specified in ACPI Spec 4.0a Appendix B, adds special support to handle multiple output devices such as panels and TV-out capabilities, brightness control as well as special power management features.</p>
 
@@ -276,7 +274,7 @@ ACPI Video Extensions
 
 
 <!-- REMOVED; need investigation, possibly easier to use DragonFlyBSD's compatibility layer to get all drivers from Linux
-<h4><img src="/images/App_Generic_32.png"/>Nouveau / PSCNV port</h4>
+<h3><img src="/images/App_Generic_32.png"/>Nouveau / PSCNV port</h3>
 <p>
 Haiku currently doesn't have a driver for NVidia video cards, and falls back to VESA for those. While our VESA driver is reasonably fast, it can't set the native display resolution on all systems, leading to a suboptimal Haiku experience.</p>
 <p>
@@ -290,7 +288,7 @@ Nouveau is a graphics driver for NVidia video cards.
 -->
 
 
-<h4><img src="/images/Misc_OtherRenderer.png"/>GPU acceleration support</h4>
+<h3><img src="/images/Misc_OtherRenderer.png"/>GPU Acceleration Support</h3>
 <p>
 Haiku does not currently support GPU acceleration, for 3D or otherwise. Reusing
 most of the DRM drivers from Linux, and Mesa's Gallium userspace components,
@@ -317,9 +315,7 @@ Linux API compatibilty layer; more investigation is needed here.</p>
 <a id="kernel" name="kernel"></a>
 <h3>Kernel</h3>
 
-<h4><img src="/images/App_Generic_32.png"/>
-Power Management
-</h4>
+<h3><img src="/images/App_Generic_32.png"/>Power Management</h3>
 
 <p>Haiku already has some power management support in the form of a CPU idling driver. This is however clearly not sufficient, and there is room for improvements in several areas in order to make Haiku use less power and make laptops running Haiku last longer on battery.</p>
 <p>Some investigation is required to identify the main issues in Haiku leading to suboptimal performance. There are however a few already known problems:</p>
@@ -331,9 +327,7 @@ Power Management
 <li>Skill set: kernel development, general C/C++, userland development, debugging, power management / measurement</li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>
-Improving the btrfs filesystem
-</h4>
+<h3><img src="/images/App_Generic_32.png"/>Improving the btrfs filesystem</h3>
 <p>Haiku has great support for its own file system, but most others are only
 available read-only. It is way better for interoperability with other systems
 to be able to write to these disks from Haiku.</p>
@@ -359,13 +353,11 @@ Skill set: kernel, and driver development
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
-Porting Apple NTFS driver to Haiku
-</h4>
+<h3><img src="/images/App_Generic_32.png"/>Porting Apple NTFS driver to Haiku</h3>
 
 <p>Haiku currently supports NTFS using code from the NTFS-3G project, which is
-distributed under the GPL license. We would prefer to use Apple implementation,
-which is under 3 clause BSD, more suitable for us.</p>
+distributed under the GPL license. We would prefer to use Apple's implementation,
+which is under the 3 clause BSD license, which is a more suitable license for us.</p>
 <p>Investigate the code in Apple NTFS driver and see how to map it to Haiku
 filesystem APIs, either by adding a compatibility wrapper (preferred, it makes
 updates easier), or by adjusting the NTFS code.</p>
@@ -376,25 +368,23 @@ updates easier), or by adjusting the NTFS code.</p>
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>Adding write support for more filesystems</h4>
+<h3><img src="/images/App_Generic_32.png"/>Adding write support for more filesystems</h3>
 
-<h5>Idea description</h5>
+<h4>Idea description</h4>
 
 <p>Some filesystems can only be read, but not written, from Haiku. The goal of this idea is to add write support for one of these filesystems (of your choice, from the list below).</p>
 
 <ul>
-<li><a href="http://en.wikipedia.org/wiki/Xfs">XFS</a> (<a href="http://xfs.org/index.php/Main_Page">Development community</a>, <a href="http://oss.sgi.com/projects/xfs/index.html">homepage</a>) is a filesystem originally developed for the IRIX operating system. Today it is commonly used by Haiku developers who build Haiku from Linux, because of its better support for extended filesystem attributes (unlike ext4).
-
-	Update: You are recommended to look at the current status of XFS. We are in the process of merging XFS v2. XFS v3 has been out for a long time and bringing read support for it could be a better idea before jumping to providing write support. This may require some discussion and we encourage you to reach out to us.</li>
+<li><a href="http://en.wikipedia.org/wiki/Xfs">XFS</a> (<a href="http://xfs.org/index.php/Main_Page">Development community</a>, <a href="http://oss.sgi.com/projects/xfs/index.html">homepage</a>) is a filesystem originally developed for the IRIX operating system. Today it is commonly used by Haiku developers who build Haiku from Linux, because of its better support for extended filesystem attributes (unlike ext4).</li>
 <li><a href="http://en.wikipedia.org/wiki/Unix_File_System">UFS2</a> (<a href="https://github.com/freebsd/freebsd/tree/master/sys/ufs/ufs">FreeBSD implementation</a>, <a href="http://sourceforge.net/p/ufs2tools/code/HEAD/tree/trunk/ufs2tools/">u2fstools for windows</a>) is the default filesystem in FreeBSD, commonly used by some Haiku developers as well. It is closely based on the original Unix filesystem, which is implemented in many other operating system. The original design is quite simple, however the different implementations in various systems make it a bit more complex to handle all cases. Focusing specifically on the FreeBSD variant is acceptable for this project if needed.</li>
 </ul>
 
-<h5>Why we need this</h5>
+<h4>Why we need this</h4>
 
 <p>In its current state, Haiku is rarely used as the single operating system on a computer. It is common to dual boot it with other systems such as Linux or FreeBSD. In this setup, it is
 very convenient when each system can access and modify the other's files. Disk partitions and data can then be shared more easily.</p>
 
-<h5>Further details</h5>
+<h4>Further details</h4>
 
 <ul><li>
 Skill set: data structures, C++
@@ -403,9 +393,9 @@ Skill set: data structures, C++
 </ul>
 
 <!-- Removed for now, we have enough filesystems
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Adding a new filesystem to Haiku
-</h4>
+</h3>
 <p>Haiku has great support for its own file system, but is completely missing support for some other filesystems. It is way better for interoperability with other systems to be able to read and write to these disks.</p>
 <p>The goal of this project is to port one of the following filesystems to Haiku:</p>
 <ol>
@@ -422,9 +412,7 @@ Adding a new filesystem to Haiku
 -->
 
 
-<h4><img src="/images/App_Generic_32.png"/>
-Filesystems benchmarking and stress-test
-</h4>
+<h3><img src="/images/App_Generic_32.png"/>Filesystems benchmarking and stress-test</h3>
 
 <p>Some of the filesystems (or specific features of them) in Haiku are
 relatively new, and not considered perfectly tested and stable yet. The goal of
@@ -444,9 +432,9 @@ Then, an automated way to run the tests should be defined (unit tests, integrati
 
 
 
-<h4><img src="/images/App_Generic_32.png"/>x86-64: Implement support for Process Context Identifiers (PCID)</h4>
+<h3><img src="/images/App_Generic_32.png"/>x86-64: Implement support for Process Context Identifiers (PCID) on Intel CPUs</h3>
 
-<p>on Intel CPUs. The feature tags TLB entries with the Id of the address space and allows to
+<p>The feature tags TLB entries with the Id of the address space and allows to
 avoid TLB invalidation on the context switch, it is available only on x86-64.</p>
 <p>The goal of this task is to propose possible designs, implement the feature, extend the performance
 logs to measure impacts when the feature is enabled, and potentially also to mitigate the
@@ -461,7 +449,7 @@ Skill set: kernel development, x86 architecture/assembly language
 
 <!-- On hold because the kernel currently doesn't boot at all. If we can't figure it out, nor can we
 guide students through it.
-<h4><img src="/images/App_Generic_32.png"/>ARM port / device tree support</h4>
+<h3><img src="/images/App_Generic_32.png"/>ARM port / device tree support</h3>
 
 <p>Unlike x86 systems which have a PCI bus, most ARM devices have peripherals at hardcoded addresses. This means automatic hardware discovery is not possible. The Linux kernel developers designed a solution called "flattened device tree". It is a static description of the hardware, telling the kernel where devices are located and which driver to use.</p>
 
@@ -478,7 +466,7 @@ Skill set: kernel development, ARM architecture/assembly
 
 
 <!-- Mentors wanted
-<h4><img src="/images/App_Generic_32.png"/>Unify File System Caches</h4>
+<h3><img src="/images/App_Generic_32.png"/>Unify File System Caches</h3>
 
 <p>
 The Haiku kernel provides two kinds of caches for use by file system implementations: the <a href="https://cgit.haiku-os.org/haiku/tree/src/system/kernel/cache/file_cache.cpp">file cache</a> and the <a href="https://cgit.haiku-os.org/haiku/tree/src/system/kernel/cache/block_cache.cpp">block cache</a>. The file cache caches data at the "file" level, while the block cache is used at the "block" level and is used for on-disk structures as well as file data.</p>
@@ -505,9 +493,9 @@ Skill set: kernel development
 <h3>Network</h3>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Bluetooth Stack Improvements
-</h4>
+</h3>
 <p>Haiku's Bluetooth stack implements a basic subset of general Bluetooth functionality. This functionality needs to be
 completed and Bluetooth 2.X and later possibilities explored. This task involves investigating the current state of the
 Bluetooth code, improving the existing code on newer devices (pairing, etc), and improving the stack
@@ -520,9 +508,9 @@ networking, etc).</p>
 <li>Possible mentors/knowledgeable people: waddlesplash <!-- also possibly PulkoMandy --></li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"\>
+<h3><img src="/images/App_Generic_32.png"\>
 VPN Support
-</h4>
+</h3>
 <p>With the decline of internet freedoms (Government IP Blocks, Net Neutrality reductions), the usage of encrypted virtual
 networks is increasing across all platforms.  Haiku's VPN implementation is severly lacking.  To improve global access
 to Haiku as a desktop platform of choice, our VPN support needs a lot of work. OpenVPN or Wireguard are both great options.</p>
@@ -533,9 +521,9 @@ to Haiku as a desktop platform of choice, our VPN support needs a lot of work. O
 <li>Possible mentors/knowledgeable people: kallisti5 <!-- also possibly PulkoMandy, waddlesplash --></li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Integrate our PPP implementation
-</h4>
+</h3>
 <p>Finish porting the PPP implementation to our new network stack. Add phone-line modem support, including HDLC
 framing and VJC compression (porting both algorithms is sufficient, but make sure the license is compatible to MIT).
 Implement CHAP authentication, and add support for configuring these to the new network preflet GUI. Find and fix bugs.</p>
@@ -547,18 +535,18 @@ Implement CHAP authentication, and add support for configuring these to the new 
 
 <!--
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Stream Control Transmission Protocol (SCTP)
-</h4>
+</h3>
 <p>Implement and test SCTP, a message based transport layer protocol similar to TCP and UDP. It should comply with current IP and IPv6 implementations and provide similar programming API as BSD.</p>
 <ul>
 <li>Skill set: network protocols, kernel and network stack development</li>
 </ul>
 -->
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 IPv6 finalization
-</h4>
+</h3>
 <p>
 The base framework for IPv6 support was implemented as a Google Summer of Code 2010 project. Even so, there remains a lot of
 smaller cleanup/finalization tasks that can be done as a project.
@@ -579,20 +567,20 @@ smaller cleanup/finalization tasks that can be done as a project.
 
 <ul>
 <li>Skill set: IPv4 and IPv6 protocols, kernel and network stack development</li>
-<li>Possible mentors: </li>
+<li>Possible mentors: jua</li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>MDNS / Bonjour / Avahi network discovery</h4>
+<h3><img src="/images/App_Generic_32.png"/>MDNS / Bonjour / Avahi network discovery</h3>
 
-<h5>Idea description</h5>
+<h4>Idea description</h4>
 
 <p>MDNS (known as Bonjour for Apple devices and usually implemented using Avahi on Linux) is a protocol allowing to discover devices in the local network and their capabilities. The goal of this project is to implement MDNS in Haiku and integrate it in our name resolution system and user interface.</p>
 
-<h5>Why we need this</h5>
+<h4>Why we need this</h4>
 
 <p>MDNS is part of the IPP Everywhere and Airprint specifications, which allow to use networked printers with a single generic driver, instead of a specific driver for each printer. Having an implementation in Haiku would allow easier setup and use of printers, a required feature for a desktop operating system.</p>
 
-<h5>Further details</h5>
+<h4>Further details</h4>
 
 <ul>
 	<li>Skill set: network programming (UDP, IPv4, multicast)</li>
@@ -603,9 +591,9 @@ smaller cleanup/finalization tasks that can be done as a project.
 <h3>User Interface</h3>
 
 <!-- removed: needs to be thought out on the mailing list a little better
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Preferences GUI refactoring
-</h4>
+</h3>
 <p>
 Haiku is an operating system designed for ease of use on desktop computers. A key part of this work is an easy to use set of preference applications. Some of the currently available preference panels could be merged or improved in several ways.</p>
 <p>
@@ -626,9 +614,9 @@ Several preference applications (aka preflets) could be redesigned. Furthermore,
 -->
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Modular edit view (BIG)
-</h4>
+</h3>
 
 <p>The current solution for text editing in Haiku is the BTextView. It is a
 rather simple view providing basic text editing features and limited styling.
@@ -647,7 +635,7 @@ to cover more use cases.</p>
 </ul>
 </p>
 
-<h5>Existing work</h5>
+<h4>Existing work</h4>
 <p>The HaikuDepot application includes preliminary work on a rich text view,
 which it uses to provide the description of packages. This could be used as a
 starting point for this work.</p>
@@ -664,7 +652,7 @@ starting point for this work.</p>
 -->
 
 <!-- needs to be discussed more; working on a MediaKit2 may make more sense. (Didn't Dan0 have MediaKit2?)
-<h4><img src="/images/App_Generic_32.png"/>Add subtitle support to the Media Kit</h4>
+<h3><img src="/images/App_Generic_32.png"/>Add subtitle support to the Media Kit</h3>
 
 <p>Haiku "media" applications rely on a framework called the Media Kit. This
 provides a unified API to handle audio and video streams, including codec
@@ -699,7 +687,7 @@ the BeBook introduction for the Media Kit</a> to become familiar with its design
 -->
 
 <!-- Mentors wanted
-<h4><img src="/images/App_Generic_32.png"/>Complete and Finalize the MediaPlayer Plugin API</h4>
+<h3><img src="/images/App_Generic_32.png"/>Complete and Finalize the MediaPlayer Plugin API</h3>
 
 <p>The MediaPlayer app included in Haiku is able to play most of the media
 formats around. To be able to do that it includes a monolithic framework that
@@ -736,9 +724,9 @@ Some efforts have been already put and can be found <a href="https://github.com/
 
 
 <!--
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Implement system wide and application level input/output chooser
-</h4>
+</h3>
 <p>
 When more than one soundcard is attached to Haiku, you can only change the default input/output in the Media preferences, or reconnect media nodes manually via Cortex to another input/output device.
 The Media Kit could support default nodes per application (either unset (system default), or set to a specific device), and the Media preferences could offer an UI to change this.
@@ -753,19 +741,19 @@ Part of this work would be to implement non-volatile storage that the Media Kit 
 
 <ul>
 <li>Skill set: general C/C++, userland development</li>
-<li>Possible mentors: </li>
+<li>Possible mentors: jua</li>
 </ul>
 -->
 
 
 <!--
-<h4><img src="/images/App_Generic_32.png"/>Improving Clockwerk</h4>
+<h3><img src="/images/App_Generic_32.png"/>Improving Clockwerk</h3>
 
 <p>Clockwerk is a video editing bench for Haiku. It works well, but it is a bit
 unstable and the feature set is not that complete.</p>
 - TODO complete the description -
 <ul>
-	<li>Possible mentors: n</li>
+	<li>Possible mentors: jua</li>
 </ul>
 -->
 
@@ -773,13 +761,13 @@ unstable and the feature set is not that complete.</p>
 <h3>Ports</h3>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Porting the Go Programming Language to Haiku
-</h4>
+</h3>
 
 <p>Go (or Golang) is a popular cross-platform general-purpose programming language which is known for its direct compilation to static executables, concurrency model used in its goroutines and its enforced standard style of programming. It has been used by many developers to create command-line tools, static site generators, high-performance servers and many other applications requiring Go.
 
-<h5>Existing work</h5>
+<h4>Existing work</h4>
 
 There was a previous GSoC student who originally ported Go 1.3 to Haiku, but unfortunately it was unmaintained and was broken over the years. In 2018, the port was later updated to Go 1.4.3 but only for 64 bit. Work has been attempted in bootstrapping higher versions like 1.5 and 1.11 but the bootstrap process have produced binaries that are broken and don't work.
 
@@ -804,9 +792,9 @@ The goal of this project is to identify the issue preventing the bootstrap proce
 <h3>Other</h3>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Jam (build system) replacement/rewrite
-</h4>
+</h3>
 <p>Haiku uses Jam as its main build system. Unfortunately, Perforce is not actively
 maintaining the tool anymore and the codebase is not very clean. Ingo Weinhold
 started work on <a href="https://github.com/weinhold/ham">a complete rewrite</a> of the tool in C++, with the aim of being
@@ -819,9 +807,9 @@ Haiku, as well as other projects currently using Jam as a buildtool.</p>
 	<li>Possible mentors: waddlesplash</li>
 </ul>
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Coding style checker bot for Gerrit
-</h4>
+</h3>
 <p>Haiku has its own <a href="/development/coding-guidelines/">coding guidelines</a>
 which describe how the code should be formatted. There is <a href="https://github.com/owenca/haiku-format">a tool</a> for reformatting
 or checking if code follows these guidelines, but it has to be compiled on the
@@ -837,9 +825,9 @@ which would run haiku-format, and then post the result as comments in Gerrit poi
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Add Haiku support to Allegro 5.0
-</h4>
+</h3>
 <p>Allegro is a gaming library. Older version (4.4) did support Haiku, but this
 support was dropped from the newer versions (starting from 5.0). The library
 should be ported to Haiku, allowing to run the bundled examples and possibly
@@ -854,9 +842,9 @@ port some other software using it.</p>
 
 <!-- REMOVED: needs more thinking on Haiku side to decide on a plan for this.
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Modify the app_server to support compositing
-</h4>
+</h3>
 <p>This would be a step towards faster/smoother scrolling, window positioning and drawing. Once compositing is in place, it would also be possible to create Compiz-like effects in Haiku, eg. drop shadows, transparent windows, content previews, and window animations.</p>
 <p>There's lots of info on what would need to be done and how to go about it in this article: /articles/2011-06-15_how_transform_app_server_code_use_compositing .</p>
 <ul>
@@ -865,21 +853,21 @@ Modify the app_server to support compositing
 -->
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 Multiple monitors output in app_server
-</h4>
+</h3>
 <p>app_server is Haiku's graphics server and the equivalent of X11 or Wayland on other UNIX systems. It currently supports only one video output, but should be able to do more.</p>
 <p>While the API already allows this for the most part (with the BScreen class), there is no actual implementation behind it and parts of the code assume only a single screen.</p>
 <p>Some drivers implement minimal support for multiple displays, but not all of them. This task may involve updating the video drivers to handle multiple monitors correctly.</p>
 <ul>
 <li>Skill set: C++, graphics development</li>
-<li>Possible mentors/knowledgeable people: PulkoMandy</li>
+<li>Possible mentors/knowledgeable people: jua, PulkoMandy</li>
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 	External font loading in app_server/interface kit
-</h4>
+</h3>
 <p>app_server is the graphics server in Haiku. It handles the rendering and
 display of application windows, desktop, and everything that is shown on screen.</p>
 <p>The Interface Kit is the API allowing apps to send commands to app_server and show things on
@@ -896,9 +884,9 @@ in app_server.</p>
 </ul>
 
 
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 	Complex font rendering in app_server
-</h4>
+</h3>
 <p>app_server is the graphics server in Haiku. It handles the rendering and
 display of application windows, desktop, and everything that is shown on screen.</p>
 <p>Freetype (in combination with agg) is used to render text. While it provides
@@ -919,9 +907,9 @@ right to left text.</p>
 </ul>
 
 <!--
-<h4><img src="/images/App_Generic_32.png"/>
+<h3><img src="/images/App_Generic_32.png"/>
 RTL languages support in interface kit
-</h4>
+</h3>
 <p>The interface kit is the part of the API taking care of everything drawing related: windows, buttons, and other widgets. It is not currently able to display right-to-left languages (such as arabic) properly, making Haiku unusable for a lot of people.</p>
 <p>Font rendering should be reworked to use the HarfBuzz library, instead of just Freetype, providing support for ligatures and bidirectional text output. The Layout Kit (which handles positioning widgets in a window) should be made to work as expected with these languages (possibly inverting left and right in the window layout).</p>
 <p>This task can be extended with better support for font overlays (picking the correct font for each language automatically, probably using fontconfig), and work on input methods for some languages.</p>


### PR DESCRIPTION
Fixed typos, added alert warning for API design and kernel work, and also moved all heading types up by one, since H2 wasn't being used.