### PR TITLE
Change footer to qualify for Netlify open source plan

### DIFF
--- a/themes/shijin4/layouts/partials/footer.copyright.html
+++ b/themes/shijin4/layouts/partials/footer.copyright.html
@@ -1,4 +1,14 @@
 <footer>
+	<div style="float: right">
+		<a href="https://www.netlify.com">
+			<img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
+		</a>
+	</div>
+
 	<p>&copy; 2001-{{ now.Format "2006" }} Haiku, Inc. &mdash; Haiku&reg; and the HAIKU logo&reg; are registered trademarks of <a href="http://www.haiku-inc.org" target="_blank">Haiku, Inc.</a></p>
-	<p class="last"><a href="/index.xml">Main feed</a> | <a href="/blog/index.xml">Blog-O-Sphere feed</a></p>
+	<p class="last">
+		<a href="/index.xml">Main feed</a> |
+		<a href="/blog/index.xml">Blog-O-Sphere feed</a> |
+		<a href="/community/organization/policies/">Community policies</a>
+	</p>
 </footer>


### PR DESCRIPTION
I believe these changes will make Haiku satisfy the [Netlify Open Source Plan Policy](https://www.netlify.com/legal/open-source-policy). I decided to use one of their [badges](https://www.netlify.com/press/#badges) but we could also qualify by linking to their homepage with a text link that says "This site is powered by Netlify".

I added a link to the Community guidelines to satisfy their second bullet point in the above policy.

We were on a free plan for a long time but upgraded our plan in June last year because of more traffic due to the Beta 2 release. We have been paying quite a bit each month since then. I would like to fix that with this.

Once this is merged, we can submit their form to try to get Haiku on this plan.

I am open to adjustments to this.

This is what this looks like on my windows machine:

<img width="747" alt="footer" src="https://user-images.githubusercontent.com/637/113237638-33092b80-9275-11eb-967f-3e692837f87b.png">
