### PR TITLE
Blacklist -> Blocklist

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -255,4 +255,4 @@ The tilde {{< keyboard "~" >}} key is a dead key, used to type characters like Ã
 Use the _Keymaps_ preferences. If your preferred layout is not available there yet, you can customize an existing one by drag'n'dropping the keys around.
 
 ### Is there some kind of failsafe mode I can boot into? How do I get to it?
-You can get to the boot menu by holding {{< keyboard SHIFT >}} or pressing {{< keyboard SPACE >}} before the Haiku boot screen shows. From there you can toggle several safe mode settings, such as forcing a lower video resolution, preventing drivers from getting loaded, or disabling some hardware features by blacklisting its driver. See the [user guide's Boot Loader](/docs/userguide/en/bootloader.html) chapter.
+You can get to the boot menu by holding {{< keyboard SHIFT >}} or pressing {{< keyboard SPACE >}} before the Haiku boot screen shows. From there you can toggle several safe mode settings, such as forcing a lower video resolution, preventing drivers from getting loaded, or disabling some hardware features by blocking its driver. See the [user guide's Boot Loader](/docs/userguide/en/bootloader.html) chapter.

--- a/content/community/gsoc/2021/ideas.html
+++ b/content/community/gsoc/2021/ideas.html
@@ -156,7 +156,7 @@ to make it a more complete and useful tool. This includes working on the followi
 <ul>
 <li>Telling wether a driver is loaded for a given device and where the matching /dev entry is</li>
 <li>Giving user readable information on the device type and subtype</li>
-<li>Allowing to blacklist/disable the driver for a given device</li>
+<li>Allowing to block/disable the driver for a given device</li>
 <li>Support for USB and bluetooth devices (currently not listed at all)</li>
 <li>Generation of a "compatibility report" to help populate a hardware compatibility database for Haiku</li>
 </ul>

--- a/content/guides/daily-tasks/_index.md
+++ b/content/guides/daily-tasks/_index.md
@@ -8,7 +8,7 @@ tags = []
 <p>Haiku is a friendly operating system targeted towards end users and developers alike.  Below is a collection of daily tasks which any new user would need to use Haiku its fullest potential.</p>
 <ul>
 <li><a href='/guides/daily-tasks/install-applications'>Installing applications</a></li>
-<li><a href='/guides/daily-tasks/blacklist-packages'>Blacklisting packages</a></li>
+<li><a href='/guides/daily-tasks/blacklist-packages'>Disabling components of packages</a></li>
 <li><a href='/guides/daily-tasks/updating-system'>Updating and downgrading your system</a>
 <li><a href='/guides/daily-tasks/netservices'>Enabling network services such as ftp and ssh</a></li>
 <li><a href='/guides/daily-tasks/access_bfs_with_fuse'>Accessing BFS outside of Haiku with FUSE</a></li>

--- a/content/guides/daily-tasks/blacklist-packages.html
+++ b/content/guides/daily-tasks/blacklist-packages.html
@@ -1,21 +1,21 @@
 +++
 type = "article"
-title = "Blacklisting packages"
+title = "Disabling components of packages"
 date = "2014-01-04T20:47:52.000Z"
 tags = []
 +++
 
 <p>With the advent of package management and <a href="https://cgit.haiku-os.org/haiku/commit/?id=3a7e0b00147f7a33bc52cb75a56bde8d9652d92a">hrev46391</a>, it has become possible to prevent a packaged file from being extracted at boot time.</p>
 
-<p>In Haiku's <a href="/docs/userguide/en/bootloader.html">boot menu</a>, there is a 'Blacklist entries' option available. However, this method will only let you disable system packages, and only until the next time you reboot.</p>
+<p>In Haiku's <a href="/docs/userguide/en/bootloader.html">Boot Options menu</a>, there is a 'Disable components' option available. However, this method will only let you disable components of system packages, and only until the next time you reboot.</p>
 
-<p>As you may know, package management has made some Haiku directories read-only, so unlike in the past, it is no longer possible to just delete or rename a problematic driver or library. The blacklisting functionality addresses this issue without requiring any editing of package file content.</p>
+<p>As you may know, package management has made some Haiku folders practically read-only, so unlike in the past, it is no longer possible to just delete or rename a problematic driver or library. The functionality to disable components of packages addresses this issue without requiring any editing of package file content.</p>
 
-<p>So let's go through the few steps needed:</p>
+<p>Let's go through the few steps needed:</p>
 
 <ol>
- <li>Figure out which file in which package you want to blacklist, and whether the file is contained in a system package or in a user one.</li>
- <li>Next step is to create a text file named 'packages' in /boot/system/settings, or in /boot/home/config/settings/global. The first directory is used for blacklisting system packages, the second for user packages.</li>
+ <li>Figure out which package contains the file that you want to disable, and whether the file is in a package located in the system or user file hierarchy. You can find the containing package name with "Get info' from Tracker's context menu on that file; look for 'SYS:PACKAGE' in its 'Attributes' tab.</li>
+ <li>Next step is to create a text file named 'packages' in /boot/system/settings, or in /boot/home/config/settings/global. The first folder is used for disabling components in system packages, the second for user packages.</li>
  <li>And finally, in the 'packages' file, we put something like:
 <pre>Package 'packagename' {
 	EntryBlacklist {
@@ -23,8 +23,13 @@ tags = []
 		...
 	}
 }
+ <ul>
+  <li>'packagename' is the name of the package without version, for example 'haiku'.</li>
+  <li>'entrypath' is the relative path to the installation location, e.g. "add-ons/Translators/FooTranslator".</li>
+ </ul>
+
 </pre>
-For example, to blacklist the intel_extreme driver and the xhci driver, which are both part of the 'haiku' system package, the 'packages' file looks like this:
+For example, to disable the intel_extreme driver and the xhci driver, which are both part of the 'haiku' system package, the 'packages' file looks like this:
 <pre>Package haiku  {
 	EntryBlacklist {
 		add-ons/kernel/drivers/bin/intel_extreme
@@ -32,16 +37,13 @@ For example, to blacklist the intel_extreme driver and the xhci driver, which ar
 	}
 }
 </pre>
- <ul>
-  <li>'packagename' is the name of the package without version, for example 'haiku'.</li>
-  <li>'entrypath' is the relative path to the installation location, e.g. "add-ons/Translators/FooTranslator".</li>
- </ul>
+</li>
 </ol>
 
-<p>Any blacklisted entries will be ignored by packagefs and will no longer appear in the file system.</p>
+<p>Any disabled entries will be ignored by packagefs and will no longer appear in the file system.</p>
 
 <h3>Example</h3>
-<p>Let's look at a practical example, blacklisting the broadcom570x driver. We create a 'packages' text file in /boot/system/settings with the following content:
+<p>Let's look at a practical example, disabling the broadcom570x driver. We create a 'packages' text file in /boot/system/settings with the following content:
 
 <pre>Package haiku {
 	EntryBlacklist {

--- a/content/guides/troubleshooting/_index.md
+++ b/content/guides/troubleshooting/_index.md
@@ -25,7 +25,7 @@ The Kernel Debug Land is the debugger built into Haiku's kernel and represents a
 
 Non-fatal KDL exceptions can sometimes be worked around by typing `continue` into the KDL screen. This rarely works however as KDL exceptions are generally raised with good reason.
 
-If the source of the problem is identified in the KDL, the add-on or driver can be blacklisted using the `Blacklist entries` [bootloader menu.](/docs/userguide/en/bootloader.html)
+If the source of the problem is identified in the KDL, the add-on or driver can be disabled using the `Disable component` menu of the [bootloader ](/docs/userguide/en/bootloader.html).
 
 #### Known Issues and workarounds:
 


### PR DESCRIPTION
hrev55022 changed the term "blacklist" to "blocklist".
This PR reflects this change in all guides, the faq and the current
2021 GSoC ideas page. Older blog posts remain untouched as re-writing
history (and other people's texts) doesn't feel right (or warrented).

The file names may still contain "blacklist" in order to keep external
links working.