### PR TITLE
Moved Google Code-In Reports to News

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,8 @@
+# old Google Code-In publications
+
+/blog/scottmc/2010-11-18_2010_google_codein_contest_haiku_selected_participating_organization/	/news/2010-11-18_2010_google_codein_contest_haiku_selected_participating_organization/	302!
+/blog/scottmc/2011-11-10_2011_google_codein_contest_haiku_selected_one_eighteen_participating_organzations/	/news/2011-11-10_2011_google_codein_contest_haiku_selected_one_eighteen_participating_organzations/ 302!
+/blog/scottmc/2014-01-20_google_codein_2013_wrap_report/	/news/2014-01-20_google_codein_2013_wrap_report/	302!
+/blog/scottmc/2015-02-13_google_codein_2014_wrap_report/	/news/2015-02-13_google_codein_2014_wrap_report/	302!
+/blog/digib0y/2017-02-05_gci_2016_wrap_up_report/	/news/2017-02-05_gci_2016_wrap_up_report/	302!
+/blog/digib0y/2018-02-02_gci_2017_wrap_up_report/	/news/2018-02-02_gci_2017_wrap_up_report/	302!

--- a/content/news/2010-11-18_2010_google_codein_contest_haiku_selected_participating_organization.md
+++ b/content/news/2010-11-18_2010_google_codein_contest_haiku_selected_participating_organization.md
@@ -1,6 +1,5 @@
 +++
-type = "blog"
-author = "scottmc"
+type = "news"
 title = "2010 Google Code-In Contest, Haiku Selected as a Participating Organization"
 date = "2010-11-18T20:17:13.000Z"
 tags = ["google", "Code-In"]
@@ -33,3 +32,7 @@ For official contest rules, see the Google Code-In page.
 
 [1] http://code.google.com/opensource/gci/2010-11/index.html
 [2] https://dev.haiku-os.org/wiki/GoogleCodeInIdeas
+
+<hr>
+
+This article was originally published on [scottmc's blog](https://www.haiku-os.org/blog/scottmc/) and moved to the News section for posterity.

--- a/content/news/2011-11-10_2011_google_codein_contest_haiku_selected_one_eighteen_participating_organzations.md
+++ b/content/news/2011-11-10_2011_google_codein_contest_haiku_selected_one_eighteen_participating_organzations.md
@@ -1,6 +1,5 @@
 +++
-type = "blog"
-author = "scottmc"
+type = "news"
 title = "2011 Google Code-In Contest, Haiku Selected as One of Eighteen Participating Organzations"
 date = "2011-11-10T04:18:44.000Z"
 tags = ["Code-In", "google"]
@@ -38,3 +37,8 @@ For official contest rules, see the Google Code-In page. [4]
 [2] http://www.google-melange.com/gci/homepage/google/gci2011
 [3] https://dev.haiku-os.org/wiki/GoogleCodeInIdeas2011
 [4] http://www.google-melange.com/gci/document/show/gci_program/google/gci2011/rules
+
+<hr>
+
+This article was originally published on [scottmc's blog](https://www.haiku-os.org/blog/scottmc/) and moved to the News section for posterity.
+

--- a/content/news/2014-01-20_google_codein_2013_wrap_report.html
+++ b/content/news/2014-01-20_google_codein_2013_wrap_report.html
@@ -1,6 +1,5 @@
 +++
-type = "blog"
-author = "scottmc"
+type = "news"
 title = "Google Code-In 2013 wrap up report"
 date = "2014-01-21T05:48:38.000Z"
 tags = ["Google Code In 2013 mentors tasks"]
@@ -13,3 +12,7 @@ tags = ["Google Code In 2013 mentors tasks"]
 <p>This year we had 5 students who completed 20 or more tasks, this is more than any of our students completed during GCI 2012.  We had 42 students who completed a total of 245 tasks for Haiku which is more than have been completed in any previous year for Haiku, so it was a very good year for us.  Of the 42 students, 19 of them completed 3 or more tasks which qualified them to receive a Google Code-In 2013 t-shirt, this was also the most students we've have that completed 3 or more tasks.</p>
 
 <p>I'd like to thank the 19 Haiku mentors, which included 3 former Google Code-In students, and all 42 students who completed at least one task for Haiku this year.  Also a special thanks to those who were on irc to help handle the flood of students during the contest, for their patience in handling of all the questions and such that the students were asking.  And lastly, a special thanks to Stephanie Taylor and the rest of the team at Google for having Google Code-In, and for picking Haiku to participate again.  It was another very productive and fun Code-In.</p>
+
+<hr>
+
+This article was originally published on [scottmc's blog](https://www.haiku-os.org/blog/scottmc/) and moved to the News section for posterity.

--- a/content/news/2015-02-13_google_codein_2014_wrap_report.md
+++ b/content/news/2015-02-13_google_codein_2014_wrap_report.md
@@ -1,6 +1,5 @@
 +++
-type = "blog"
-author = "scottmc"
+type = "news"
 title = "Google Code-In 2014 Wrap Up Report"
 date = "2015-02-13T08:53:54.000Z"
 tags = ["google", "GCI", "Code-In", "haiku"]
@@ -17,3 +16,8 @@ Notable tasks this year included HaikuWeather, SuperFreeCell, bookmarkconvert an
 Last year Google invited each org to send one of their mentors along to the awards trip in San Francisco.  I made the trip and got to meet up with Puck and Freeman.  This year we asked the two winning students which mentor they'd most like to see make the trip this year, and they both picked Adrien as their number one choice, and Adrien has agreed to go.  
 
 I'd like to thank the 17 Haiku mentors and all 149 students who completed at least one task for Haiku this year. Also a special thanks to those who were on irc to help handle the flood of students during the contest.  Also a shout out to Stephanie Taylor and the rest of the team at Google for having Google Code-In, and for picking Haiku to participate.
+
+<hr>
+
+This article was originally published on [scottmc's blog](https://www.haiku-os.org/blog/scottmc/) and moved to the News section for posterity.
+

--- a/content/news/2017-02-05_gci_2016_wrap_up_report.md
+++ b/content/news/2017-02-05_gci_2016_wrap_up_report.md
@@ -1,7 +1,6 @@
 +++
-type = "blog"
+type = "news"
 title = "GCI 2016 Wrap Up Report"
-author = "digib0y"
 date = "2017-02-05 12:44:02+05:30"
 tags = ["haiku", "software","GCI","Google","students","Code-In","Google Code-In","GCI2016"]
 +++
@@ -63,3 +62,7 @@ Raefaldhi Amartya Junior from Indonesia</li>
 <p>I hope that despite probably being the best of their age in their field, the winning students will stay humble, and hunger for new knowledge.</p>
 
 <p>So congratulations and thanks to all our hardworking students and their mentors, and especially Scott McCreary who once again shouldered the responsibility of administrating Haiku’s GCI participation.</p>
+
+<hr>
+
+This article was originally published on [digib0y's blog](https://www.haiku-os.org/blog/digib0y/) and moved to the News section for posterity.

--- a/content/news/2018-02-02_gci_2017_wrap_up_report.md
+++ b/content/news/2018-02-02_gci_2017_wrap_up_report.md
@@ -1,7 +1,6 @@
 +++
-type = "blog"
+type = "news"
 title = "GCI 2017 Wrap Up Report"
-author = "digib0y"
 date = "2018-02-02 00:13:41+05:30"
 tags = ["haiku", "software","GCI","Google","students","Code-In","Google Code-In","GCI2016"]
 +++
@@ -54,3 +53,8 @@ tags = ["haiku", "software","GCI","Google","students","Code-In","Google Code-In"
 </ul>
 
 <p>So congratulations and thanks to all our hardworking students and their mentors, and especially Scott McCreary who once again shouldered the responsibility of administrating Haiku’s GCI participation.</p>
+
+<hr>
+
+This article was originally published on [digib0y's blog](https://www.haiku-os.org/blog/digib0y/) and moved to the News section for posterity.
+


### PR DESCRIPTION
Initial commit, in order to list a couple of articles that I see as worthy of being moved to the News section (Competition results) for long-term posterity reasons, SEO and organization. Many of those sorts of posts from other years were published in the News section and all of this is a bit of a mess that has to be untangled.

I'm only pushing this initial commit before making any further changes in order to make sure that this is fine by everyone.

## TO-DO:

- [x] Add redirects.
- [x] Mildly modify metadata, so that it matches with the metadata of an article. Don't modify more than what is needed.
- [x] Add corresponding notice, see below.

The original content will not be modified, and only a notice reading *This article was originally published on [author]'s blog and moved here for posterity." with a hyperlink linking back to the blog of the author.