### PR TITLE
Getting involved | Translating: Mention role of language managers

### DIFF
--- a/content/community/getting-involved/translating/_index.html
+++ b/content/community/getting-involved/translating/_index.html
@@ -12,7 +12,7 @@ tags = []
 <h2>GUI Translators</h2>
 <h5>Haiku Translation</h5>
 <p>You can help translate the Haiku Graphical User Interface into your language at the <a href="https://i18n.haiku-os.org/pootle">Haiku Interface Translation website</a>, otherwise known as Pootle. See this <a href="https://dev.haiku-os.org/wiki/i18n/GUI-Localization">introduction to GUI localization</a> guide if you would like to help out with localizations of the GUI.</p>
-
+<p>Anyone with an account at Pootle can suggest a translation for a GUI string, but only trusted "Language Managers" can submit these suggestions to be transferred to Haiku's code base. If you would like to help out in that capacity, please get in contact via the <a href="https://www.haiku-os.org/community/ml">general and language-specific mailing lists</a>.</p>
 <h5>3rd Party App Translation</h5>
 <p>3rd party applications can be localized at the <a href="https://i18n.kacperkasper.pl">Polyglot</a> site. Developers can add their project and upload the "catkeys" of their application. Users can then translate to their native language. See also the forum thread <a href="https://discuss.haiku-os.org/t/help-translating-applications-with-polyglot/6548">Help translating applications with Polyglot</a>.</p>
 <p>If you'd like to help localize existing applications, see the article <a href="https://www.haiku-os.org/community/getting-involved/translating/3rdparty">Localizing an application</a>, that gives an introduction how the app's code has to be changed.</p>


### PR DESCRIPTION
Explain that only language managers can submit suggested translations.
Point people to the mailing lists if they want to become one.
Maybe that way people know they can help out if suggested translations
begin to pile up if a language manager goes missing.