### PR TITLE
Update the BeBook redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -21,6 +21,3 @@
 # URL canonicalization
 http://haiku.netlify.com/*      https://www.haiku-os.org/:splat 301!
 https://haiku.netlify.com/*     https://www.haiku-os.org/:splat 301!
-
-# Various brokenness
-/legacy-docs/bebook             /legacy-docs/bebook/            301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -21,3 +21,6 @@
 # URL canonicalization
 http://haiku.netlify.com/*      https://www.haiku-os.org/:splat 301!
 https://haiku.netlify.com/*     https://www.haiku-os.org/:splat 301!
+
+# BeBook Redirect
+/legacy-docs/bebook             /legacy-docs/bebook/index.html  301!


### PR DESCRIPTION
Attempting to access the BeBook, receiving ERR_TOO_MANY_REDIRECTS.

According to https://docs.netlify.com/routing/redirects/redirect-options/, "You cannot use a redirect rule to add or remove a trailing slash."

  

```
  # This rule will cause an infinite redirect
  # because the paths are effectively the same
  /blog/remove-my-slashes/   /blog/remove-my-slashes  301!
```