### PR TITLE
Add update from Promotion team + update port status

### DIFF
--- a/content/blog/jt15s/2021-07-29_update_3_from_the_promotion_team.md
+++ b/content/blog/jt15s/2021-07-29_update_3_from_the_promotion_team.md
@@ -1,0 +1,45 @@
++++
+type = "blog"
+title = "Update #3 from the Promotion Team"
+author = "jt15s"
+date = "2021-07-29 12:28:21+10:00"
+tags = ["haiku", "software", "promotion"]
++++
+
+Hello all! This is the third update from the Haiku Promotion Team. 
+
+## Beta3 Released
+As you have noticed, Beta3 has been released! Huge shout out to kallisti5, who was the release coordinator for Beta3. Making a major release of Haiku is a daunting task to all involved!
+
+## New Team Members
+Since I last wrote in March this year, we welcomed the following members to the Team:
+* animortis
+* AlwaysLivid
+* jeremyf
+
+## Switching to IRC/Matrix
+It was brought to our attention that the way the Promotion Team communicated was not a very transparent one – we communicated through a group private message on the Haiku forums. Thus, the decision was made to switch to IRC/Matrix, because it is a trusted technology, and it can be accessed from all major platforms including Haiku. Now, anyone can see what we are discussing and working on and can participate in our discussions! If you wish to join, we have a discussion room at #haiku-promo on OFTC, with bridges to Matrix. 
+
+## Promotion Team Kanban
+We were also informed that our Kanban, quite paradoxically, did not work on Haiku. We are still considering options to switch, including trying out a solution from Atlassian, or using the existing Haiku development tracker. We will post on this blog once a decision has been made. 
+
+## Social Media Accounts
+You may have seen that we have requested access to the Haiku Twitter and LinkedIn accounts. We believe that the accounts have become a lot like RSS feeds, which, is not inherently bad, but for an open-source project like ours with users and developers asking for help on social media platforms, we could do a lot better. We will keep you updated once the policies for the accounts have been finalised and we start posting on the accounts.
+
+## Haiku’s 20th Anniversary
+Now that Beta3 is released, the next big event on the cards is our 20th Anniversary! If you go to the history page on this website, you can see that we started on the 18th of August 2001. 
+We will need someone to design 20th Anniversary graphics for us, so if you are up to the task, don’t hesitate to send me a PM on the forums or post in the IRC/Matrix room. 
+Currently, we have merchandise planned for this special occasion (we should have more news to share on that soon), but any ideas for events or other items for purchase are welcomed. 
+
+## Looking ahead to Beta4
+After Beta3, there will be Beta4. Why are we thinking of Beta4 so soon, you might ask? Well, the time after a major release is often a time when activity tends to slump for a bit. We want to keep that momentum going, so we are thinking of what we can do for the next major release. 
+
+We are considering putting on spotlight on many of Haiku’s built-in apps. Many of them have been neglected for years and need a developer’s TLC (tender, loving care). For example, the Mail app uses an older protocol, and the UI needs some improvement! To do this, we will put out Calls for Contributions, blog posts that let people know what needs work.  
+Additionally, there are many things that have been on our “wish list” for a while that need contributors. A single-sign-on system for all of Haiku’s web services (i.e., Trac, Gerrit, forums) is something that we have wanted for a long time. Furthermore, we still need to migrate from Pootle to another web translation service since Pootle is no longer maintained. We also need a major reorganisation of our website and documentation, as the organisation of our documentation is quite confusing. We will most likely put out Calls for Contributions for these, wherever applicable.   
+A tentative release date set on Trac is the 31st of January 2022. This is a tentative release date meaning that it is subject to change. Beta3 had the initial tentative date of sometime in April, however it was released on the 25th of July (or 26th depending on where you live in the world). It is the aim of the Haiku Project to have a major release at least once a year.  
+Additionally, there will be more tickets that will be assigned to Beta4; we have 688 active tickets in the R1 milestone so expect plenty more tickets to be added!
+If you have anything you want to see in Beta4, a [Beta4 wish list thread](https://discuss.haiku-os.org/t/beta-4-wishlist/11092) has been started on the forums so feel free to post there.
+
+## Closing Words
+As always, if you have any feedback or suggestions for the Promotion Team don’t hesitate to contact us via IRC/Matrix, or post in the forums under the Marketing category. Stay safe!
+

--- a/content/community/getting-involved/promotion/promotion-team.md
+++ b/content/community/getting-involved/promotion/promotion-team.md
@@ -16,6 +16,7 @@ The Haiku Promotion Team, in its second iteration (there used to be a Promotion 
 * fox14
 * animortis
 * AlwaysLivid
+* jeremyf
 
 ## Quick Links
 * [Kanban](https://stoltenhoff.sandcats.io/shared/54D5fg2wyv1Z3b0UZgkQp3GOZrVBtno-OyCOyqb1gmm/b/sandstorm/libreboard)

--- a/content/guides/building/port_status.html
+++ b/content/guides/building/port_status.html
@@ -60,10 +60,11 @@ real-world developer interest.<br/><br/>
 </table>
 
 <table>
-<tr><td COLSPAN=7><h3>RISC-V (Tier 2)</h3>An open-source computer architecture with many implementations. **Note that real RISC-V hardware is not yet supported. There are issues with some packages and libstdc++ is partially broken. Additionally, nightly builds are not yet available.**</td></tr>
+<tr><td COLSPAN=7><h3>RISC-V (Tier 2)</h3>An open-source computer architecture with many implementations. <strong>Note that there are issues with some packages and libstdc++ is partially broken. Additionally, nightly builds are not yet available.</strong></td></tr>
 <tr><th>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
 <tr><td>TinyEMU (raw platform)</td><td>High</td><td>riscv64</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td>Under Development</td></tr>
 <tr><td>QEMU (raw platform, SBI/EFI)</td><td>High</td><td>riscv64</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td>Under Development</td></tr>
+<tr><td>HiFive Unmatched</td><td>High</td><td>riscv64</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td>Under Development</td></tr>
 </table>
 
 <table>


### PR DESCRIPTION
Added a new update from the Promotion team and added the HiFive board to the RISC-V ports status section