### PR TITLE
Replace Google search with DuckDuckGo Search

### DIFF
--- a/themes/shijin4/layouts/partials/navbar.html
+++ b/themes/shijin4/layouts/partials/navbar.html
@@ -26,10 +26,10 @@
 			<li class="nav-item"><a class="nav-link" href="/development/">Development</a></li>
 			<li class="nav-item"><a class="nav-link" href="/documents/">Documents</a></li>
 		</ul>
-		<form class="form-inline" role="search" action="https://www.google.com/search">
-			<input type="hidden" name="as_epq" value="site:www.haiku-os.org">
+		<form class="form-inline" role="search" action="https://duckduckgo.com">
+			<input type="hidden" name="sites" value="https://www.haiku-os.org">
 			<div class="input-group">
-				<input type="text" class="form-control" placeholder="Search" name="as_q">
+				<input type="text" class="form-control" placeholder="Search" name="q">
 				<span class="input-group-append">
 					<button type="submit" class="btn btn-outline-secondary">&#x1f50d;</button>
 				</span>


### PR DESCRIPTION
Replaced Google site search with DuckDuckGo site search for privacy reasons (a lot of Haiku users don't like being redirected to Google).