### PR TITLE
Update compiling-86.md to note that xorriso is now required

### DIFF
--- a/content/guides/building/compiling-x86.md
+++ b/content/guides/building/compiling-x86.md
@@ -19,7 +19,7 @@ features available in newer gcc versions.</p>
 <p>When building from Haiku, all the required tools are already installed in
 the release image, therefore you can run configure without any arguments:
 
-(Note: Currently as of Aug-09-2021 the package "xorriso" must be installed from HaikuDepot before compiling.)</p>
+(Note: Currently as of Aug-14-2021 the package "xorriso" must be installed from HaikuDepot before compiling the anyboot image.)</p>
 
 ```sh
 ./configure

--- a/content/guides/building/compiling-x86.md
+++ b/content/guides/building/compiling-x86.md
@@ -17,7 +17,9 @@ features available in newer gcc versions.</p>
 <h3>Building Haiku from Haiku</h3>
 
 <p>When building from Haiku, all the required tools are already installed in
-the release image, therefore you can run configure without any arguments:</p>
+the release image, therefore you can run configure without any arguments:
+
+(Note: Currently as of Aug-09-2021 the package "xorriso" must be installed from HaikuDepot before compiling.)</p>
 
 ```sh
 ./configure


### PR DESCRIPTION
Update compiling-86.md to note that xorriso is now required and not integrated into the release atm.

https://dev.haiku-os.org/ticket/17161
https://discuss.haiku-os.org/t/xorriso-requirement-when-building-haiku/11173