### PR TITLE
Fix href typo in FAQ (Why isn't it called HaikuOS?)

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -10,7 +10,7 @@ Here are some Frequently Asked Questions about Haiku. For development related to
 
   * Common Questions
     * [What is Haiku?](#what-is-haiku)
-    * [Why isn't it called HaikuOS?](#why-isn-t-it-called-haikuos)
+    * [Why isn't it called HaikuOS?](#why-isnt-it-called-haikuos)
     * [Where does the name Haiku come from?](#where-does-the-name-haiku-come-from)
     * [Is Haiku based on Linux?](#is-haiku-based-on-linux)
     * [Why not Linux?](#why-not-linux)


### PR DESCRIPTION
Hi!

I was browsing through the website and tried to click on the "Why isn't it called HaikuOS" link, realizing it wasn't working. In this commit I fix that typo.

I think that's all there's needed, because I assume none of this is automatically generated.

Thanks