### PR TITLE
Add zstd_devel to list of pre-reqs on Haiku

### DIFF
--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -108,7 +108,7 @@ Note that in addition to all the platform-specific packages, you will also need 
 **Basic requirements:**
 
 ```sh
-pkgman install cmd:python3 cmd:xorriso zstd_devel
+pkgman install cmd:python3 cmd:xorriso devel:libzstd
 ```
 
 **Additional requirements for building ARM versions of Haiku:**

--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -108,7 +108,7 @@ Note that in addition to all the platform-specific packages, you will also need 
 **Basic requirements:**
 
 ```sh
-pkgman install cmd:python3 cmd:xorriso
+pkgman install cmd:python3 cmd:xorriso zstd_devel
 ```
 
 **Additional requirements for building ARM versions of Haiku:**


### PR DESCRIPTION
Closes https://dev.haiku-os.org/ticket/17431

Looks like most or all of the other host platforms list this as a pre-req