### PR TITLE
Improve clarity in compilation guides

### DIFF
--- a/content/guides/building/_index.md
+++ b/content/guides/building/_index.md
@@ -9,6 +9,10 @@ Building Haiku from sources is a surprisingly simple process which allows
 developers to get started quickly developing on Haiku and allowing end users to
 experiment with the latest Haiku sources.
 
+Please ensure that you have obtained a copy of Haiku's source code as described in
+[Get the Haiku Source Code](https://www.haiku-os.org/guides/building/get-source-git)
+if you have not already done so.
+
 ## Basics
 
 * [Port Status](/guides/building/port_status) - An overview of the platforms Haiku is designed to run on

--- a/content/guides/building/compiling-arm.md
+++ b/content/guides/building/compiling-arm.md
@@ -7,6 +7,10 @@ tags = ["compiling", "arm"]
 
 Haiku can be compiled for devices leveraging the ARMv7 or later processor architecture.
 
+Please ensure that you have obtained a copy of Haiku's source code as described in
+[Get the Haiku Source Code](https://www.haiku-os.org/guides/building/get-source-git) 
+if you have not already done so.
+
 {{< alert-danger "Unstable" "The state of the ARM port is extremely early. Roll up your sleeves and help out!">}}
 
 ## Create a Compiler Toolchain

--- a/content/guides/building/compiling-riscv64.md
+++ b/content/guides/building/compiling-riscv64.md
@@ -7,6 +7,10 @@ tags = ["compiling", "riscv64"]
 
 Haiku can be compiled for devices using the RISC-V 64bit processor architecture. (RV64GC)
 
+Please ensure that you have obtained a copy of Haiku's source code as described in
+[Get the Haiku Source Code](https://www.haiku-os.org/guides/building/get-source-git) 
+if you have not already done so.
+
 {{< alert-danger "Unstable" "The state of the RISC-V port is early. Only the bootloader currently runs." >}}
 
 ## Create a compiler toolchain

--- a/content/guides/building/compiling-sparc.md
+++ b/content/guides/building/compiling-sparc.md
@@ -7,6 +7,10 @@ tags = ["compiling", "arm"]
 
 Haiku can be compiled for devices using the SPARC 64bit processor architecture.
 
+Please ensure that you have obtained a copy of Haiku's source code as described in
+[Get the Haiku Source Code](https://www.haiku-os.org/guides/building/get-source-git) 
+if you have not already done so.
+
 {{< alert-danger "Unstable" "The state of the SPARC port is early. Only the bootloader currently runs." >}}
 
 ## Create a compiler toolchain

--- a/content/guides/building/compiling-x86.md
+++ b/content/guides/building/compiling-x86.md
@@ -14,6 +14,11 @@ as gcc8 binaries. More information on this can be found on the <a href='/guides/
 applications as well as modern one using the recent programming language
 features available in newer gcc versions.</p>
 
+<p>Please ensure that you have obtained a copy of Haiku's source code as
+described in
+<a href="https://www.haiku-os.org/guides/building/get-source-git">Get the Haiku Source Code</a> 
+if you have not already done so.</p>
+
 <h3>Building Haiku from Haiku</h3>
 
 <p>When building from Haiku, all the required tools are already installed in

--- a/content/guides/building/compiling-x86_64.md
+++ b/content/guides/building/compiling-x86_64.md
@@ -32,32 +32,40 @@ mkdir generated.x86_64; cd generated.x86_64
 x86_64 Haiku Builds
 ===================
 
+Please ensure that you have obtained a copy of Haiku's source code as described in
+[Get the Haiku Source Code](https://www.haiku-os.org/guides/building/get-source-git)
+if you have not already done so.
+
 These builds require a valid x86_64 compiler toolset (see above), and might also
 need additional software packages installed -- see the
 <a href="/guides/building/pre-reqs">pre-requisite software</a> page for more details.
 
-These commands should be run from the same path you ran your configure in above.
+The following commands should be run in the same directory as the one you
+ran `./configure` on.
 
-Compiling a nightly anyboot Haiku iso image
---------------------------------------
+Anyboot (`.iso`) images
+----------------------------------
 
 This is the standard build which results in a live ISO that can be burned
-to an optical disc, or that can be written directly to a USB stick.
+to an optical disc, or that can be written directly to a USB stick. An
+anyboot image should work with the overwhelming majority of virtualization
+software out there.
 
-{{< alert-info "Build Threads" "Be sure to modify -j2 with the number of cpu cores on your build system to ensure the fastest build times.">}}
+{{< alert-info "Build Threads" "The 2 in `-j2` stands for the number of CPU cores that should be used. Make sure to modify that number in order to compile Haiku faster.">}}
 
 ```sh
 jam -q -j2 @nightly-anyboot
 ```
 
-
-Compiling a nightly raw disk images
----------------------------------
+Raw disk images
+----------------
 
 This generates a simple raw disk image of Haiku which can be booted directly in
-a VM or written directly to a USB stick.
+a VM or written directly to a USB stick. Raw disk images generally consist of
+exact, sector-by-sector copies of a disk. It may make sense to use those,
+for example, if you are using QEMU from a command line interface (CLI).
 
-{{< alert-info "Build Threads" "Be sure to modify -j2 with the number of cpu cores on your build system to ensure the fastest build times.">}}
+{{< alert-info "Build Threads" "The 2 in `-j2` stands for the number of CPU cores that should be used. Make sure to modify that number in order to compile Haiku faster.">}}
 
 ```sh
 jam -q -j2 @nightly-raw


### PR DESCRIPTION
- Add notice that directs people to download the Haiku
  source code, if they have not already done so. This
  will be helpful, as many people open these guides
  directly after looking for them with a search engine.
- Improve headers in 'Compiling for x86_64' guide.
- The PowerPC guide was not updated, as the guide has
  not been updated in a decent amount of time and
  updating it, which would be required in order to
  include the notice I added in the previous documents,
  will require extensive amounts of effort.