### PR TITLE
remove Gumstix and Efika from port status page

### DIFF
--- a/content/guides/building/port_status.html
+++ b/content/guides/building/port_status.html
@@ -25,12 +25,6 @@ real-world developer interest.<br/><br/>
 <tr class="platform"><td><a href="http://www.cubieboard.org/">Cubieboard 4</a></td><td>Moderate</td><td>cubieboard4</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
 <tr class="platform"><td><a href="http://www.raspberrypi.org/">Raspberry Pi 3</a></td>
 	<td>Moderate</td><td>rpi3</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>20%</td></tr>
-<tr class="platform"><td>Gumstix <a href="http://www.gumstix.org/hardware-design/verdex-pro-coms.html" title="Verdex">Verdex</a> (emu)</td>
-	<td>Low</td><td>verdex</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
-<tr class="platform"><td>Gumstix <a href="http://www.gumstix.org/hardware-design/overo-coms.html">Overo</a></td>
-	<td>Low</td><td>overo</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
-<tr class="platform"><td>Genesi <a href="http://www.genesi-tech.com/products/efika">Efika MX</a></td>
-	<td>Moderate</td><td>???</td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>10%</td></tr>
 </table>
 
 <table>


### PR DESCRIPTION
It seems there's not much activity on the Gumstix or Efika platforms so perhaps we can remove them from the port status?

Unless someone has plans to support them. (even though it might not be so easy especially for the verdex as it seems to have max 128MB RAM according to gumstix.com)