### PR TITLE
add port status for qemu arm

### DIFF
--- a/content/guides/building/port_status.html
+++ b/content/guides/building/port_status.html
@@ -21,6 +21,12 @@ real-world developer interest.<br/><br/>
 <table>
 <tr><td COLSPAN=7><h3>ARM (Tier 2)</h3>Newly revitalized line of processors excelling at low power consumption and low cost. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/arm">platform-specific notes</a> in the source tree.</td></tr>
 <tr class="port"><th width=350>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
+<tr class="platform"><td>QEMU (EFI)</td><td>Moderate</td><td>arm</td>
+	<td><img src='/files/status-icons/complete.png' alt='Complete'></td>
+	<td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td>
+	<td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td>
+	<td>30%</td>
+</tr>
 <tr class="platform"><td><a href="http://beagleboard.org" title="BeagleBoard">BeagleBoard</a> Black</td><td>Moderate</td><td>beagle</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>20%</td></tr>
 <tr class="platform"><td><a href="http://www.cubieboard.org/">Cubieboard 4</a></td><td>Moderate</td><td>cubieboard4</td>
 	<td><img src='/files/status-icons/need-maintainer.png' alt='Need Maintainer'></td>


### PR DESCRIPTION
hello gents,

i think the qemu-arm port deserves an entry on the port status page, as some effort went into it recently...
surely it's in a better shape than the arm hw platforms listed already (e.g. more icons light up on the splash screen) so i'd estimate it as 30% status