### PR TITLE
replace yaourt with Paru in /content/guides/buidling/pre-reqs.md.

### DIFF
--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -145,7 +145,7 @@ sudo pacman -S base-devel multilib-devel bison git texinfo nasm openssh unzip zs
 **Additional requirements for building ARM versions of Haiku:**
 
 ```sh
-sudo pacman -S yaourt uboot-tools
+sudo pacman -S paru uboot-tools
 ```
 
 <a name="yum"></a>


### PR DESCRIPTION
 yaourt is dead, use paru instead. 

I have open a ticket on Trac as well. Here's the link: https://dev.haiku-os.org/ticket/17694
