### PR TITLE
update port status for arm64

### DIFF
--- a/content/guides/building/port_status.html
+++ b/content/guides/building/port_status.html
@@ -40,7 +40,18 @@ real-world developer interest.<br/><br/>
 <table>
 <tr><td COLSPAN=7><h3>ARM64 (Tier 2)</h3>Newly revitalized line of processors excelling at low power consumption and low cost. See <a href="https://git.haiku-os.org/haiku/tree/docs/develop/kernel/arch/arm">platform-specific notes</a> in the source tree.</td></tr>
 <tr class="port"><th width=350>Platform</th><th>Interest</th><th>Target</th><th>Haiku Loader</th><th>Haiku Kernel</th><th>Application Server</th><th>Status</th></tr>
-<tr class="platform"><td><a href="http://www.raspberrypi.org" title="Raspberry Pi 4+">Raspberry Pi 4+</a></td><td>High</td><td>arm64</td><td><img src='/files/status-icons/complete.png' alt='Complete'></td><td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td><td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td><td>30%</td></tr>
+<tr class="platform"><td>QEMU (EFI)</td><td>Moderate</td><td>arm64</td>
+	<td><img src='/files/status-icons/complete.png' alt='Complete'></td>
+	<td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td>
+	<td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td>
+	<td>30%</td>
+</tr>
+<tr class="platform"><td><a href="http://www.raspberrypi.org" title="Raspberry Pi 4+">Raspberry Pi 4+</a></td><td>High</td><td>arm64</td>
+	<td><img src='/files/status-icons/in-progress.png' alt='In Progress'></td>
+	<td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td>
+	<td><img src='/files/status-icons/no-work.png' alt='No Work Complete'></td>
+	<td>10%</td>
+</tr>
 </table>
 
 <table>


### PR DESCRIPTION
Hello guys,

Based on recent forum activity and my tests with the rpi4, I think the current arm64 status on the port_status might be a bit too optimistic...


QEMU:
bootloader: is in a good shape, considering the recent code contributions from Milek and Oliver. The haiku_loader.efi binary builds. We get successful jump to kernel.
kernel: I'd say in progress - there's some good activity but the current HEAD fails quite early in the kernel initialization
userspace: probably no one started looking into this yet

RPI4:
bootloader: afaik it's possible to get some valid output but we need many kludges. Not sure if there's any successful jump to kernel though.
kernel: it doesn't look like there's much activity on this. I expect it will need some more effort once the kernel starts to work in qemu (e.g. drivers, but also cache and TLB maintenance, memory barriers etc - these are just too easy to overlook when one is working in an emulator)
userspace: ditto

please let me know if I missed something