### PR TITLE
pre-reqs/pacman: Add bc.

### DIFF
--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -139,7 +139,7 @@ sudo apt-get install u-boot-tools util-linux device-tree-compiler
 **Basic requirements:**
 
 ```sh
-sudo pacman -S base-devel multilib-devel bison git texinfo nasm openssh unzip zstd curl wget flex xorriso python lib32-glibc
+sudo pacman -S base-devel multilib-devel bison git texinfo nasm openssh unzip zstd curl wget flex xorriso python lib32-glibc bc
 ```
 
 **Additional requirements for building ARM versions of Haiku:**


### PR DESCRIPTION
On a current minimal Arch Linux install the required `bc` package is not present, so this adds it to the list of required packages. I've only tested a build on Arch Linux, so `bc` might just be a newer requirement that needs to be added to other distros too.