### PR TITLE
Up/downgrade guide: Updated instructions

### DIFF
--- a/content/guides/daily-tasks/updating-system.html
+++ b/content/guides/daily-tasks/updating-system.html
@@ -5,39 +5,40 @@ date = "2014-08-18T13:11:00.000Z"
 tags = ["update"]
 +++
 
-<p>With the introduction of package management you can now upgrade your system in place using the pkgman command.  The update process is straightforward, requires an internet connection, and requires a single reboot. pkgman will handle obtaining the latest updates and applying them to your system.</p>
+<p>Since the introduction of package management you can update your system in place using the pkgman command or the <a href="https://www.haiku-os.org/docs/userguide/en/applications/softwareupdater.html">SoftwareUpdater</a> application. The update process is straightforward, requires an internet connection, and requires a single reboot. pkgman/SoftwareUpdater will handle obtaining the latest updates and applying them to your system.</p>
 
 <h2>Bleeding edge</h2>
 
+Besides normal updates of your installed software and stable Haiku release, you can switch Haiku to Nightly builds (and back to stable release).
+
 <div class="alert alert-warning"><strong>Warning:</strong> Bleeding edge updates may occasionally fail if major ABI updates have taken place since the last update was performed.  While problems are rare, having backups is recommended before updating.</div>
 
-<h1>Update process</h1>
-<p>To update your system to packages in the repositories, there are a few simple steps to perform. (do <b>not</b> add single quotes around the urls, the $(getarch) is meant to be substituted by the shell)</p>
+<h1>Switching to Stable/Nightly builds</h1>
+<p>To update your system to packages in the respective repository, there are a few simple steps to perform. (do <b>not</b> add single quotes around the urls, the $(getarch) is meant to be substituted by the shell)</p>
+
+<h2>Nightly (unstable) builds</h2>
+<ul>
+ <li>Add the recommended stock nightly repository:<br/>
+ <pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/master/$(getarch)/current</pre></li>
+ <li>Update to the latest packages:<br/><pre class="terminal">pkgman full-sync</pre></li>
+ <li>Reboot once complete:<br/><pre class="terminal">shutdown -r</pre></li>
+</ul>
 
 <h2>Stable (r1beta3 in this example) builds</h2>
 <div class="alert alert-info">HaikuPorts is currently 'master' for both Stable and Nightly builds.</div>
 <ul>
- <li>Add the recommended stock stable (r1beta3) repositories:<br/><pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/r1beta3/$(getarch)/current
-pkgman add https://eu.hpkg.haiku-os.org/haikuports/master/$(getarch)/current</pre></li>
- <li>Update to the latest packages:<br/><pre class="terminal">pkgman update</pre></li>
- <li>Reboot once complete:<br/><pre class="terminal">shutdown -r</pre></li>
-</ul>
-
-<h2>Nightly (unstable) builds</h2>
-<ul>
- <li>Add the recommended stock nightly repositories:<br/><pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/master/$(getarch)/current
-pkgman add https://eu.hpkg.haiku-os.org/haikuports/master/$(getarch)/current</pre></li>
- <li>Update to the latest packages:<br/><pre class="terminal">pkgman update</pre></li>
+ <li>Add the recommended stock stable (r1beta3) repositoris:<br/>
+ <pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/r1beta3/$(getarch)/current</pre></li>
+ <li>Update to the latest packages:<br/><pre class="terminal">pkgman full-sync</pre></li>
  <li>Reboot once complete:<br/><pre class="terminal">shutdown -r</pre></li>
 </ul>
 
 <h1>Freeing some disk space</h1>
-<p>When updating, old packages are kept in directories named "state_..." in <tt>/system/packages/administrative/</tt> to allow booting with previous states in case update fails. After a while you might want to free up some disk space. You can safely remove the oldest state folders there, as well as the "transaction-..." ones. Do not touch the other directories though.</p>
+<p>When updating, old packages are kept in directories named "state_..." in <tt>/system/packages/administrative/</tt> to allow booting with previous states in case an update fails. After a while you might want to free up some disk space. You can safely remove the oldest state folders there, as well as the "transaction-..." ones. Do not touch the other directories though.</p>
 
 <h1>Downgrading to a previous revision</h1>
 <p>It's possible that an update to the latest Haiku revision (hrev) introduced a regression you're not willing to live with. From the boot options menu you can load a former, working hrev (see the user guide's <a href="https://www.haiku-os.org/docs/userguide/en/bootloader.html#troubleshooting">Boot Loader - Troubleshooting</a>). Find the last working state and boot into it.</p>
-<p>To permanently downgrade to this revision, you have to point the 'Haiku' and 'HaikuPorts' repositories to that hrev. You find the current revision under "About Haiku" from the Deskbar. As example, for hrev50380:</p>
-<pre class="terminal">pkgman add https://packages.haiku-os.org/haiku/master/$(getarch)/r1~alpha4_pm_hrev50380
-pkgman add https://packages.haiku-os.org/haikuports/master/repo/$(getarch)/by_hrev/hrev50380</pre>
-<p>With "<tt>pkgman full-sync</tt>" you can now downgrade to that hrev50380.</p>
+<p>To permanently downgrade to this revision, you have to point the 'Haiku' repository to that hrev. You find the current revision under "About Haiku" from the Deskbar. As example, for hrev56231:</p>
+<pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/master/$(getarch)/r1~beta3_hrev56231</pre>
+<p>With "<tt>pkgman full-sync</tt>" you can now downgrade to that hrev56231.</p>
 <p>Note, that you're now 'stuck' with that revision. You should report the regression and help to fix it, if you can. Once fixed - watch the <a href="http://cgit.haiku-os.org/haiku/log/">commit logs</a> -  you can change back to the "current" repo.</p>


### PR DESCRIPTION
* Mention SoftwareUpdater as pkgman alternative. The easiest way
  for end-users to stay updated.

* Reversed order of instructions to switch to/from Stable/Nightly.
  Normally, people start switching from Stable to Nightly and only
  later (sometimes) vice-versa.

* HaikuPorts is 'master' for both Stable and Nightly builds.
  Removed the "pkgman add" of the haikuports repo when switching
  Stable/Nightly because they stay the same.

* Use "pkgman full-sync" instead of "pkgman update". Safer when
  switching from Nightly back to Stable.

* Updated repo URL used to downgrade.

Fixes Trac ticket 17818:
https://dev.haiku-os.org/ticket/17818