### PR TITLE
get source: improve instructions

### DIFF
--- a/content/guides/building/get-source-git.md
+++ b/content/guides/building/get-source-git.md
@@ -101,7 +101,7 @@ git config --global user.email "john.doe@example.com"
 
 Although most contributors tend to disclose their real names, we do not have
 a real name policy and plenty of contributors contribute to Haiku using a pseudonym.
-That means that it is possible for anyone to contribute.
+You are not required to use your "real" name, a pseudonym is fine and several Haiku contributors chose to do that. However, make sure the e-mail address is correct and working, it is what we will use if we need to contact you later.
 
 On macOS, you must set the following option in order to avoid problems with the
 unicode representation of filenames:

--- a/content/guides/building/get-source-git.md
+++ b/content/guides/building/get-source-git.md
@@ -27,7 +27,7 @@ Haiku, you need to follow the instructions for patch submitters in the next
 section.
 </div>
 
-<div class="alert alert-warning">
+<div class="alert alert-info">
 <strong>The buildtools repository is not needed when building from within 32-bit Haiku</strong>.
 In that version, the tools required to build Haiku are included by default.
 </div>

--- a/content/guides/building/get-source-git.md
+++ b/content/guides/building/get-source-git.md
@@ -9,23 +9,27 @@ tags = []
 
 <span class="right"><img src='/images/archive_64.png'></span>
 
-Haiku's source code is currently being hosted in a <a href="http://git-scm.com/" target="_blank">Git based repository</a> with <a href="https://gerritcodereview.com">Gerrit code review</a>.
-Anonymous access will allow anyone to download Haiku's source code; However, the authenticated (non-anonymous) method is required for submitting patches.
+Haiku's source code is currently being hosted on a
+<a href="http://git-scm.com/" target="_blank">Git-based repository</a> using <a href="https://gerritcodereview.com" target="_blank">Gerrit</a>.
 
-Although most contributors tend to disclose their real names, we do not have a real name policy and
-a couple of contributors contribute to Haiku pseudonymously. That means that it's possible for anyone to contribute.
+If you are already familiar with the pull request workflow as used, for example, on GitHub, you
+can find an overview of the differences in <a href="https://gerrit-review.googlesource.com/Documentation/intro-gerrit-walkthrough-github.html" target="_blank">Gerrit user's manual</a>.
 
-<div class="alert alert-warning">
-<strong>The buildtools are not needed when building from within 32-bit Haiku</strong>. Pre-built images of 32-bit Haiku already come with suitable buildtools pre-installed.
-</div>
+Anonymous access will allow anyone to download Haiku's source code; However,
+the authenticated (non-anonymous) method is required for submitting patches.
 
 <a name="anon_access"></a>
 <h3>Git Access - Anonymous testers</h3>
 
 <div class="alert alert-warning">
 <strong>Anonymous access is read-only.</strong> If you want to submit changes to
-Haiku, you need to follow the instructions for patch submitters, in the next
+Haiku, you need to follow the instructions for patch submitters in the next
 section.
+</div>
+
+<div class="alert alert-warning">
+<strong>The buildtools repository is not needed when building from within 32-bit Haiku</strong>.
+In that version, the tools required to build Haiku are included by default.
 </div>
 
 <h4>Build Tools:</h4>
@@ -40,26 +44,67 @@ git clone https://review.haiku-os.org/buildtools
 git clone https://review.haiku-os.org/haiku
 ```
 
-If you don't care about the commit history and want to keep the download small,
-try using the parameter `--depth` when cloning. `--depth 10` limits the history
-to the last 10 commits, for example.
+If you don't care about the commit history and want to limit the download size,
+use the parameter `--depth` when cloning. For example, `--depth 10` limits the
+history to the last 10 commits.
+
+<h4>GitHub</h4>
+
+If your Internet provider limits the websites you are allowed to use, you can use
+our mirror repositories <a href="https://github.com/haiku/haiku" target="_blank">on GitHub</a>
+instead.
+
+They are kept in sync with our main repository, however, these repositories do
+not have any Git tags, which the compiler uses to determine the revision of
+Haiku. To work around this limitation, you can use the
+<a href="https://cgit.haiku-os.org/haiku/tree/build/jam/UserBuildConfig.ReadMe" target="_blank">HAIKU_REVISION build variable</a>
+when building Haiku.
+
+The commands for cloning the repositories from GitHub are:
+
+<h4>Build Tools:</h4>
+
+```sh
+git clone http://github.com/haiku/buildtools.git
+```
+
+<h4>Haiku:</h4>
+
+```sh
+git clone http://github.com/haiku/haiku.git
+```
 
 <a name="dev_access"></a>
 <h3>Git Access - Contributors and patch submitters</h3>
 
+So, you want to contribute to Haiku. That's awesome, thank you for your
+interest! This section will include instructions for setting up your local Git
+environment, an account on our Gerrit instance, as well as some guidelines on
+how to work with other contributors to get your changes included. This guide
+assumes that you are new to contributing to open-source projects. If that
+is not the case, you can skip some of the sections.
+
+<h4>A visual overview of our Git workflow</h4>
+<img src='/files/gitProcess_0.png' alt='A diagram describing the way our Git workflow works. This picture is there for aesthetic purposes and can be skipped. After a repository is cloned locally, if you have an idea, you can convert that idea into a commit using food (a pizza is depicted in the diagram). That commit will receive some change proposals, which will result in some further changes. The circle continues until the change is ready to be included in Haiku itself.'>
+
+<h4>Configuring Git locally<a name="configure_env"></a></h4>
+
 <div class="alert alert-danger">
-<strong>Configure your git!</strong> Before making any commits to the Haiku repository (local even), be <strong>sure</strong> to <a href="#configure_env">configure</a> the Git environment on your local system! Failure to configure git properly before a commit will result in incorrect naming in your commit, making it impossible to give you well-deserved credit for your work.</div>
+<strong>This section is important!</strong> Failing to configure Git properly before a commit will result in an incorrect name being used in your commit, making it impossible to give you well-deserved credit for your work.</div>
 
-<h4>Configure Git on your system:<a name="configure_env"></a></h4>
-
-Before making your first commit on a new system, be <strong>sure</strong> to configure Git. These global settings are stored in your git configuration directory (`~/.git/` or for Haiku: `~config/settings/git/`) and will be appended to <strong>each</strong> commit as your personal information.
+A global Git configuration is stored in Git configuration directory (`~/.git/` or for Haiku: `~/config/settings/git/`) and will be included in <strong>every</strong> commit.
 
 ```sh
 git config --global user.name "John Doe"
-git config --global user.email "john.doe@developers.com"
+git config --global user.email "john.doe@example.com"
 ```
 
-On macOS, you must set the following option in order to avoid problems with the unicode representation of filenames:
+Although most contributors tend to disclose their real names, we do not have
+a real name policy and plenty of contributors contribute to Haiku using a pseudonym.
+That means that it is possible for anyone to contribute.
+
+On macOS, you must set the following option in order to avoid problems with the
+unicode representation of filenames:
 
 ```sh
 git config core.precomposeunicode true
@@ -67,114 +112,82 @@ git config core.precomposeunicode true
 
 <h4>Setup an account on Gerrit</h4>
 
-<p>Log in to <a href="https://review.haiku-os.org">Gerrit code review</a>. You currently need a <a href="https://github.com">Github</a> account for logging in.</p>
+<p>Log in to <a href="https://review.haiku-os.org" target="_blank">Gerrit code review</a>. For the time being, using a <a href="https://github.com">GitHub account</a> is necessary.</p>
 
 <div class="alert alert-warning">
-Make sure your ssh key is generated with ed25519. RSA keys will not work with Gerrit.
+Make sure your SSH key is generated using <code class="code">ed25519</code>. RSA keys will <strong>not</strong> work with Gerrit.
 </div>
-<p>Upload your SSH public key in <a href="https://review.haiku-os.org/settings/#SSHKeys">Gerrit SSH keys settings</a> page. If you don't have a key yet, you can generate one using ssh-keygen.</p>
-<p>If the e-mail address used in your commits does not match the one in your github account, you will need to add and verify it in <a href="https://review.haiku-os.org/settings/#EmailAddresses">Gerrit E-Mail address settings</a>.</p>
+
+<p>Upload your SSH public key in the <a href="https://review.haiku-os.org/settings/#SSHKeys" target="_blank">Gerrit SSH Keys settings</a> page. If you don't have a key yet, you can generate one using ssh-keygen.</p>
+
+<h4>Cloning repositories from Gerrit</h4>
+
+<p>If the email address used in your commits does not match the one in your Github account, you will need to add and verify it in <a href="https://review.haiku-os.org/settings/#EmailAddresses" target="_blank">Gerrit email address settings</a>.</p>
+
+<div class="alert alert-warning">
+You may need to replace the <code class="varname">$USER</code> parameter in the following commands.
+</div>
+<p>This can happen if the username on your Gerrit account does not match the username that you use to log in to your computer. This would be the case in Haiku itself, as the default username is <code class="code">user</code>.</p>
+<p><code class="varname">$USER</code> is an environment variable that is specific to Unix-like operating systems (e.g. Haiku, Linux, FreeBSD, etc.). If your system does not fall under that category, you will probably have to replace it.</p>
 
 <h4>Build Tools:</h4>
 
-The `<login>@` is only needed if your currently logged in username doesn't match your `review.haiku-os.org` username.
-
 ```sh
-git clone "ssh://<login>@git.haiku-os.org/buildtools" && scp -p <login>@git.haiku-os.org:hooks/commit-msg "buildtools/.git/hooks/"
+git clone "ssh://$USER@git.haiku-os.org/buildtools" && scp -p $USER@git.haiku-os.org:hooks/commit-msg "buildtools/.git/hooks/"
 ```
 
 <h4>Haiku:</h4>
 
-The `<login>@` is only needed if your currently logged in username doesn't match your `review.haiku-os.org` username.
-
 ```sh
-git clone "ssh://<login>@git.haiku-os.org/haiku"
-scp -p <login>@git.haiku-os.org:hooks/commit-msg "haiku/.git/hooks/"
+git clone "ssh://$USER@git.haiku-os.org/haiku" && scp -p $USER@git.haiku-os.org:hooks/commit-msg "haiku/.git/hooks/"
 ```
 
-<h4>Switching from read-only to write access</h4>
+<h4>Preparing your first patch</h4>
 
-Want to submit your first patch? Thanks, that's great! You don't need to checkout the sources again. Instead you can update your existing copy of the source to use the commiter access. Just change the remote URL:
-
-```sh
-git remote set-url origin ssh://<login>@git.haiku-os.org/haiku
-```
-
-You also should install the <a href="https://review.haiku-os.org/Documentation/user-changeid.html">Gerrit hooks to generate Change-Ids</a>:
+Before making a commit, install a Git hook that will automatically
+<a href="https://review.haiku-os.org/Documentation/user-changeid.html" target="_blank">generate Change-Id's</a>
+for you:
 
 ```sh
-scp -p <login>@git.haiku-os.org:hooks/commit-msg "haiku/.git/hooks/"
+scp -p $USER@git.haiku-os.org:hooks/commit-msg "haiku/.git/hooks/"
 ```
 
-<h3>Some Notes</h3>
+If a maintainer asks you to correct something later on, Gerrit will use that
+Change-Id to keep track of your newest changes.
 
-<h4>Case Sensitive Filesystem</h4>
+<div class="alert alert-warning">
+You should review our
+<a href="https://www.haiku-os.org/development/coding-guidelines/" target="_blank">Coding Guidelines</a>
+before making a commit and submitting a change.
+</div>
+
+If you wish to change something in your commit, you can amend it in retrospect
+making them using <span class="cli">git add .</span> and <span class="cli">git commit --amend</span>.
+
+<h4>Case Sensitive Filesystems</h4>
 
 <div class="alert alert-warning">
 Haiku's source code needs to reside on a case sensitive file system.
 </div>
-In short, such a file system recognizes "ThisIsAFile.txt" and "THISISAFILE.txt" as two different files. Some file systems that are (or could be) case in-sensitive include, FAT32, NTFS, and HFS+. macOS's HFS+ is case in-sensitive by default. For more information regarding how to create a case-sensitive HFS+ volume, see <a href="/documents/dev/how_build_haiku_mac_os_x#part_diskimage">this article</a>.
 
-<a name="proxy_access"></a>
-<h4>Getting the source code through an HTTP proxy</h4>
+In short, such a file system recognizes ThisIsAFile.txt and THISISAFILE.txt as
+two different files. Some file systems that are (or could be) case insensitive
+include FAT32, NTFS, and HFS+.
 
-<div class="alert alert-warning">
-Haiku's main Git repository does not allow HTTP access, which is a problem if you are accessing the Internet through a proxy server that only permits HTTP (port 80) traffic.
-</div>
+macOS's HFS+ is also case insensitive by
+default, but that can be changed: See
+<a href="/documents/dev/how_build_haiku_mac_os_x#part_diskimage" target="_blank">this article</a>
+for more information.
 
-Instead, use one of our mirror repositories at GitHub or Gitorious for anonymous HTTP access, they are both kept in sync with the main repository. First, set Git to connect through your proxy server:
 
-```sh
-git config --global http.proxy http://proxyuser:proxypwd@proxy.server.com:8080
-```
+<h3>Commit Message Standards</h3>
 
-Then clone the repositories from GitHub:
-
-```sh
-git clone http://github.com/haiku/buildtools.git
-git clone http://github.com/haiku/haiku.git
-```
-
-Please note that these repositories do not contain any `hrev` tags, which are used by the Haiku build system to determine the Haiku revision. To work around this limitation, use the <a href="https://cgit.haiku-os.org/haiku/tree/build/jam/UserBuildConfig.ReadMe" target="_blank">HAIKU_REVISION build variable</a> when building Haiku.
-
-<h3>Common tasks</h3>
-
-If you are already familiar with the pull request workflow as used, for example, at GitHub, you
-can find an overview of the differences in <a href="https://gerrit-review.googlesource.com/Documentation/intro-gerrit-walkthrough-github.html">Gerrit user's manual</a>.
-
-<h4>Example git workflow</h4>
-<img src='/files/gitProcess_0.png'>
-
-<h4>Updating the Sources</h4>
-
-<div class="alert alert-danger">
-Be sure to use the <span class="cli">--rebase</span> argument while doing a pull prior to a push to avoid confusing nonlinear histories! ("Merge 'master' on ssh://git.haiku-os.org/haiku" messages showing your name and others changes) Do <b>NOT</b> however use <span class="cli">--rebase</span> on branches you have shared with other people! (rebase re-writes the local history. If your local history doesn't match people who cloned off of you, and they want to push to you, they will have <b>major</b> problems.)
-</div>
-
-```sh
-cd haiku
-git pull --rebase
-```
-
-You can make git take care of this automatically for you, so that "git pull" does the right thing for Haiku:
-
-```sh
-cd haiku
-git config pull.rebase true
-```
-
-Alternatively, a single path or multiple paths can be given to <span class="cli">git pull</span>. This will allow you to run the following command from any directory. This becomes extremely useful if you use an <a href="/guides/building/configure/different-generated">external object directory</a> or if you wish to update both the buildtools and haiku directories at the same time.
-
-```sh
-git pull --rebase ./haiku ./buildtools
-```
-
-<h4>Making local commits</h4>
+<h4>Making a new commit</h4>
 
 In Git, you make commits to your local tree, then push the final results to the
-central remote Haiku repository. Split your work in not too large commits, but
-remember that each commit will be reviewed separately, so don't make them too
-small either.
+central remote Haiku repository. Split your work in commits that are
+not too large commits, but remember that each commit will be reviewed
+separately, so don't make them too small either.
 
 The commit message will also be reviewed, and should describe the change in
 as much detail as possible. You can refer to other commits by either their hrev
@@ -193,15 +206,13 @@ Here is an example of a good commit message:
 ```
 kernel: Perform the usual early morning tasks
 
-* Ensure cats in computer are fed.
+* Ensure cats are fed.
 * Clean up white space.
-* The retroencabulator needs to be adjusted to accept input from
-  multiple sources of data and ensure the buffer is free for
-  shenanigans.
-* No functional change.
+* Adjust retroencabulator to accept input from multiple sources of data
+  and ensure the buffer is free for shenanigans.
 ```
 
-<h5>Short commit comment</h5>
+<h4>Short commit messages</h4>
 
 If your commit is very short, you can include it directly on the Git command line:
 
@@ -209,9 +220,9 @@ If your commit is very short, you can include it directly on the Git command lin
 git commit -a -m "WebPositive: Style cleanup, no functional change"
 ```
 
-<h5>Long commit comments</h5>
+<h4>Long commit messages</h4>
 
-If your commit message is longer, you can put it in a file and use it this way:
+If you want to make a longer commit message, you can put it in a file and use it this way:
 
 ```sh
 git commit -a -F ~/mycommitlog
@@ -220,30 +231,96 @@ git commit -a -F ~/mycommitlog
 Alternatively, you can use "git commit -a", which will open a text editor and
 let you write down the message when you commit your changes.
 
-It may be a good idea to check <a href="https://review.haiku-os.org">Gerrit</a>
+It may be a good idea to check <a href="https://review.haiku-os.org" target="_blank">Gerrit</a>
 as a point of reference if you are not sure how you should format your
 commit message.
 
+<h4>Amending commits</h4>
+
+Commit messages, as well as the contents of a commit itself, can be corrected
+using <span class="cli">git commit --amend</span>.
+
+<h3>Common tasks</h3>
+
+<h4>Updating the source code</h4>
+
+This section assumes that you are actively working on new commits and need to
+test them on a newer revision of the source code.
+
+<div class="alert alert-danger">
+When using <span class="cli">git pull</span>, use the
+<span class="cli">--rebase</span> argument while doing a pull prior to a push
+to avoid confusing non-linear histories! (<span class=cli>"Merge 'master' on
+ssh://git.haiku-os.org/haiku"</span> messages showing your name and changes
+that are not related to yours)
+
+Do <strong>NOT</strong> use <span class="cli">--rebase</span> on branches you
+have shared with other people! (rebase re-writes the local history. If your
+local history doesn't match people who cloned off of you, and they want to push
+to you, they will have <strong>major</strong> problems.)
+</div>
+
+You can make Git take care of this automatically for you, so that
+<span class="cli">git pull</span> does the right thing for Haiku:
+
+```sh
+cd haiku
+git config pull.rebase true
+```
+
+Alternatively, a single path or multiple paths can be given to
+<span class="cli">git pull</span>. This will allow you to run the following
+command from any directory. This becomes extremely useful if you use an
+<a href="/guides/building/configure/different-generated" target="_blank">external object directory</a>
+or if you wish to update both the buildtools and haiku directories at the same
+time.
+
+```sh
+git pull --rebase ./haiku ./buildtools
+```
+
 <h4>Pushing changes for review</h4>
+
+Assuming that your local repository's remote URL points to Gerrit and that you
+have configured your environment as previously described in this document,
+this should work:
 
 ```sh
 git push origin HEAD:refs/for/master -o topic="something"
 ```
 
-After your changes are complete, the push command will push your local tree to the remote Haiku repository.
-The commits will be added to the review page and people will review them. You can then amend your commits
-and push them again, until they are reviewed and merged.
+After your changes are complete, the push command will push your local tree
+to the remote Haiku repository. The commits will be added to the
+<a href="https://review.haiku-os.org" target="_blank">review page</a> and
+people will review them. You can then amend your commits and push them again,
+until they are reviewed and merged.
 
 It is recommended to set a topic - a single keyword that can easily be searched
 for in the web interface and help categorize commits.
 
-<h4>Taking review comments into account and updating a commit</h4>
+<h5>GitHub</h5>
 
-Usually your changes will not be accepted on the first try. Other developers
+<div class="alert alert-danger">
+<strong>Do not send pull requests using GitHub!</strong> Pull requests for the
+Haiku operating system using GitHub cannot be accepted for technical reasons.
+However, this may not be the case with some other repositories.
+</div>
+
+To submit a patch, you can change the remote URL of the Haiku repository to
+Gerrit using this command:
+
+```sh
+git remote set-url origin ssh://$USER@git.haiku-os.org/haiku
+```
+
+<h4>Assessing review comments and updating a commit</h4>
+
+Usually, your changes will not be accepted on the first try. Other developers
 will review it, making sure they understand what you are doing, and maybe
 help you find better ways of doing it. They will also check that your code
-follows the coding guidelines, which are important to make sure the code is
-easy to read and uses the same conventions in all the codebase.
+follows the <a href="https://www.haiku-os.org/development/coding-guidelines/">coding guidelines</a>,
+which are important to make sure the code is easy to read and uses the same
+conventions that other contributors use as well.
 
 <h5>Single-commit change</h5>
 
@@ -322,7 +399,8 @@ You can use git commit --amend to edit the latest commits and add more commits
 to the branch. To modify the previous commits, you need to use git interactive
 rebase (git rebase -i). See <pre>git help rebase</pre> for more help on rebasing.
 
-Once you are done, you can update your patches on Gerrit:
+Once you are done, you can update the patches that you have previously
+submitted for review:
 
 ```sh
 git push origin HEAD:refs/for/master


### PR DESCRIPTION
- Commands can now be copied and pasted on a variety of systems using user environment variable. As this is not a catch-all solution, a sufficient warning was added.
- Replace example domains with "example.com"
- Improve some headers
- Add some additional background information for better onboarding
- Add additional warning for GitHub pull requests
- Fix English
- Make the tone more informal as to not intimidate new contributors