### PR TITLE
Update to Doxygen 1.9.6

### DIFF
--- a/scripts/build_for_deploy.sh
+++ b/scripts/build_for_deploy.sh
@@ -23,8 +23,8 @@ pushd haiku
 	if [ ! -d generated ]; then
 		mkdir generated
 		pushd generated
-		wget https://nchc.dl.sourceforge.net/project/doxygen/rel-1.8.16/doxygen-1.8.16.linux.bin.tar.gz -O doxygen.tar.gz -nv
-		tar -xvf doxygen.tar.gz doxygen-1.8.16/bin/
+		wget https://nchc.dl.sourceforge.net/project/doxygen/rel-1.9.1/doxygen-1.9.1.linux.bin.tar.gz -O doxygen.tar.gz -nv
+		tar -xvf doxygen.tar.gz doxygen-1.9.1/bin/
 		mkdir doxybin
 		mv doxygen-*/bin/* doxybin/
 		rm -rf doxygen-*/

--- a/scripts/build_for_deploy.sh
+++ b/scripts/build_for_deploy.sh
@@ -23,8 +23,8 @@ pushd haiku
 	if [ ! -d generated ]; then
 		mkdir generated
 		pushd generated
-		wget https://nchc.dl.sourceforge.net/project/doxygen/rel-1.9.1/doxygen-1.9.1.linux.bin.tar.gz -O doxygen.tar.gz -nv
-		tar -xvf doxygen.tar.gz doxygen-1.9.1/bin/
+		wget https://nchc.dl.sourceforge.net/project/doxygen/rel-1.9.6/doxygen-1.9.6.linux.bin.tar.gz -O doxygen.tar.gz -nv
+		tar -xvf doxygen.tar.gz doxygen-1.9.6/bin/
 		mkdir doxybin
 		mv doxygen-*/bin/* doxybin/
 		rm -rf doxygen-*/


### PR DESCRIPTION
While working on https://dev.haiku-os.org/ticket/17209 I got a warning on my local Debian install that the Doxyfile was out of date. So I updated it. It seems good to use a more recent Doxygen version for the docs. Local generation works OK with this version, not tested with the script and Netlify but I don't expect too much problems?