### PR TITLE
fix message about sha hash on macOS

### DIFF
--- a/content/get-haiku/r1beta4/_index.md
+++ b/content/get-haiku/r1beta4/_index.md
@@ -108,9 +108,10 @@ c184e609a6c0021f9acd2df9fc111c2e12d01107d01f943fbea66c936b063f88  haiku-r1beta4-
 </pre>
 
 <p>
-	If you are in Haiku, macOS or Linux, you can use the <code>sha256sum</code>
+	If you are in Haiku or Linux, you can use the <code>sha256sum</code>
 	command from the Terminal to generate a checksum for your downloaded
-	file and verify against those above. If you are in Windows, you can use
+	file and verify against those above. If you are in macOS, you can use
+  the <code>shasum -a 256</code> command. If you are in Windows, you can use
 	the shell command <code>certutil -hashfile</code> on the ISO file.
 </p>
 

--- a/content/get-haiku/r1beta4/_index.md
+++ b/content/get-haiku/r1beta4/_index.md
@@ -111,7 +111,7 @@ c184e609a6c0021f9acd2df9fc111c2e12d01107d01f943fbea66c936b063f88  haiku-r1beta4-
 	If you are in Haiku or Linux, you can use the <code>sha256sum</code>
 	command from the Terminal to generate a checksum for your downloaded
 	file and verify against those above. If you are in macOS, you can use
-  the <code>shasum -a 256</code> command. If you are in Windows, you can use
+	the <code>shasum -a 256</code> command. If you are in Windows, you can use
 	the shell command <code>certutil -hashfile</code> on the ISO file.
 </p>
 


### PR DESCRIPTION
sha256sum isn't on macOS; it's shasum -a 256. I just changed the message.