### PR TITLE
Add verification attribute to Mastodon footer link

### DIFF
--- a/themes/shijin4/layouts/partials/footer.copyright.html
+++ b/themes/shijin4/layouts/partials/footer.copyright.html
@@ -11,7 +11,7 @@
 		<a href="/blog/index.xml">Blog-O-Sphere feed</a> |
 		<a href="/community/organization/policies/">Community policies</a> |
 		<a href="https://twitter.com/haikuOS">Twitter</a> |
-		<a href="https://mastodon.xyz/@haiku">Mastodon</a> |
+		<a rel="me" href="https://mastodon.xyz/@haiku">Mastodon</a> |
 		<a href="https://www.linkedin.com/company/haiku-inc-">LinkedIn</a>
 	</p>
 </footer>


### PR DESCRIPTION
Adds `rel="me"` to the Mastodon account link in the footer. This will enable verification of the website link on Haiku's Mastodon profile.

Mastodon documentation for link verification as reference:
https://docs.joinmastodon.org/user/profile/#verification