### PR TITLE
get-source-git.md: mention the need to `chmod +x` the `commit-msg` script

### DIFF
--- a/content/guides/building/get-source-git.md
+++ b/content/guides/building/get-source-git.md
@@ -140,6 +140,7 @@ git clone "ssh://$USER@git.haiku-os.org/buildtools" && curl -Lo "buildtools/.git
 
 ```sh
 git clone "ssh://$USER@git.haiku-os.org/haiku" && curl -Lo "haiku/.git/hooks/commit-msg" https://review.haiku-os.org/tools/hooks/commit-msg
+chmod +x haiku/.git/hooks/commit-msg
 ```
 
 <h4>Preparing your first patch</h4>
@@ -150,6 +151,7 @@ for you:
 
 ```sh
 curl -Lo "haiku/.git/hooks/commit-msg" https://review.haiku-os.org/tools/hooks/commit-msg
+chmod +x haiku/.git/hooks/commit-msg
 ```
 
 If a maintainer asks you to correct something later on, Gerrit will use that


### PR DESCRIPTION
Not sure if it also applies to buildtools, but without `chmod+ x`, the `commit-msg` is not properly run. And not sure if this should be solved elsewhere instead, but...

I've noticed this after I've decided to update the original `commit-msg` I downloaded a couple years ago, with the one that's provided now (after the Gerrit update, and such). "Change-Id" wasn't being added at all.

Seems to be tripping some new contributors lately too.