### PR TITLE
gsoc2024: fixed broken link

### DIFF
--- a/content/community/gsoc/2024/contributors.html
+++ b/content/community/gsoc/2024/contributors.html
@@ -241,7 +241,7 @@ In addition to the mentor(s) assigned to each GSoC contributor, the following re
 	<li><a href="https://cgit.haiku-os.org/haiku/plain/ReadMe.Compiling.md">Building Haiku from source</a> (single plain text file)</li>
 	<li><a href="/guides/building">Building Haiku from source</a> (html)</li>
 	<li><a href="/guides/installing">Installing Haiku</a></li>
-	<li><a href="https://www.haiku-os.org/docs/develop">A Brief Introduction to our Source Repository Layout</a></li>
+	<li><a href="https://www.haiku-os.org/docs/develop/build/sourcecode.html">A Brief Introduction to our Source Repository Layout</a></li>
 	<li><a href="/development/coding-guidelines">Coding Guidelines</a></li>
 	<li><a href="https://dev.haiku-os.org/wiki/SubmittingPatches">Submitting a patch to Haiku</a></li>
 

--- a/content/community/gsoc/2024/contributors.html
+++ b/content/community/gsoc/2024/contributors.html
@@ -241,7 +241,7 @@ In addition to the mentor(s) assigned to each GSoC contributor, the following re
 	<li><a href="https://cgit.haiku-os.org/haiku/plain/ReadMe.Compiling.md">Building Haiku from source</a> (single plain text file)</li>
 	<li><a href="/guides/building">Building Haiku from source</a> (html)</li>
 	<li><a href="/guides/installing">Installing Haiku</a></li>
-	<li><a href="/documents/dev/a_brief_introduction_to_our_source_repository_layout">A Brief Introduction to our Source Repository Layout</a></li>
+	<li><a href="https://www.haiku-os.org/docs/develop">A Brief Introduction to our Source Repository Layout</a></li>
 	<li><a href="/development/coding-guidelines">Coding Guidelines</a></li>
 	<li><a href="https://dev.haiku-os.org/wiki/SubmittingPatches">Submitting a patch to Haiku</a></li>
 


### PR DESCRIPTION
Fixed broken link https://www.haiku-os.org/documents/dev/a_brief_introduction_to_our_source_repository_layout 
It now redirects to the new https://www.haiku-os.org/docs/develop/