### PR TITLE
Coding Guidelines: correct incorrect brace whitespace after class def…

### DIFF
--- a/content/development/coding-guidelines.md
+++ b/content/development/coding-guidelines.md
@@ -82,8 +82,8 @@ Foo::Bar(const char* bar1, T bar2)
 
 
 // Empty functions in class definitions can be written on a single line
-class Example
-{
+class Example {
+public:
 		void			FooFunction() {}
 };
 


### PR DESCRIPTION
…inition

Most of our code and the rest of this document uses the convention that the open brace in a class definition is on the same line. There is an odd example here that did not follow that convention.

See also: https://github.com/owenca/haiku-format/issues/33