### PR TITLE
Adds beta5 repos to the instructions for system ugprades

### DIFF
--- a/content/guides/daily-tasks/updating-system.html
+++ b/content/guides/daily-tasks/updating-system.html
@@ -24,11 +24,11 @@ Besides normal updates of your installed software and stable Haiku release, you 
  <li>Reboot once complete:<br/><pre class="terminal">shutdown -r</pre></li>
 </ul>
 
-<h2>Stable (r1beta3 in this example) builds</h2>
+<h2>Stable (r1beta5 in this example) builds</h2>
 <div class="alert alert-info">HaikuPorts is currently 'master' for both Stable and Nightly builds.</div>
 <ul>
- <li>Add the recommended stock stable (r1beta3) repositoris:<br/>
- <pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/r1beta3/$(getarch)/current</pre></li>
+ <li>Add the recommended stock stable (r1beta5) repositoris:<br/>
+ <pre class="terminal">pkgman add https://eu.hpkg.haiku-os.org/haiku/r1beta5/$(getarch)/current</pre></li>
  <li>Update to the latest packages:<br/><pre class="terminal">pkgman full-sync</pre></li>
  <li>Reboot once complete:<br/><pre class="terminal">shutdown -r</pre></li>
 </ul>


### PR DESCRIPTION
There's a bit further down about downgrading and currently references what I assume is the hrev before beta3 was branched off. Was looking at Gerrit and failing to work out where beta5 was branched from.