### PR TITLE
correct zstd dev package name to libzstd-devel for RPM distros

### DIFF
--- a/content/guides/building/pre-reqs.md
+++ b/content/guides/building/pre-reqs.md
@@ -156,7 +156,7 @@ sudo pacman -S paru uboot-tools
 **Basic requirements:**
 
 ```sh
-sudo yum install git nasm autoconf automake texinfo flex bison gcc gcc-c++ make glibc-devel zlib-devel zstd-devel xorriso curl-devel byacc libstdc++-static glibc-devel.i686 libstdc++-devel.i686 libstdc++-devel python36
+sudo yum install git nasm autoconf automake texinfo flex bison gcc gcc-c++ make glibc-devel zlib-devel libzstd-devel xorriso curl-devel byacc libstdc++-static glibc-devel.i686 libstdc++-devel.i686 libstdc++-devel python36
 ```
 
 <a name="zypper"></a>


### PR DESCRIPTION
While following the instruction to build and run Haiku I encountered an issue when trying to install the prerequisites.

In particular on RPM-based systems the correct package name appears to be `libzstd-devel`.

https://pkgs.org/download/libzstd-devel

I've tested on Fedora Linux 44